### PR TITLE
Add currency selector to website search

### DIFF
--- a/website/app/[locale]/page.tsx
+++ b/website/app/[locale]/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation'
 import { getTranslations } from 'next-intl/server'
 import HomeSearchForm from '../home-search-form'
 import GlobeButton from '../globe-button'
+import CurrencyButton from '../currency-button'
 import { getGitHubStars, formatStars } from '../../lib/github-stars'
 import { getTrackedSourcePath, isProbeModeValue } from '../../lib/probe-mode'
 
@@ -152,6 +153,7 @@ export default async function Home({ params, searchParams }: { params: Promise<{
 
           <div className="lp-topbar-side">
             <GlobeButton inline />
+            <CurrencyButton inline behavior="refresh" />
             <a
               href={REPO_URL}
               target="_blank"

--- a/website/app/book/[offerId]/page.tsx
+++ b/website/app/book/[offerId]/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { getTranslations } from 'next-intl/server'
 import GlobeButton from '../../globe-button'
+import CurrencyButton from '../../currency-button'
 import BookPageClient from './BookPageClient'
 import { appendProbeParam, getTrackedSourcePath, getTrackingSearchId, isProbeModeValue } from '../../../lib/probe-mode'
 
@@ -202,6 +203,7 @@ export default async function BookPage({
             </div>
             <div className="res-topbar-actions">
               <GlobeButton inline />
+              <CurrencyButton inline behavior="refresh" />
               <a
                 href={REPO_URL}
                 target="_blank"

--- a/website/app/currency-button.tsx
+++ b/website/app/currency-button.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useRouter } from 'next/navigation'
+import { Coins, DollarSign, Euro, PoundSterling, SwissFranc, type LucideIcon } from 'lucide-react'
 import {
   CURRENCY_CHANGE_EVENT,
   DISPLAY_CURRENCIES,
@@ -13,14 +14,17 @@ import {
 } from '../lib/currency-preference'
 import { getTrackedSourcePath } from '../lib/probe-mode'
 
-function CoinsIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <ellipse cx="12" cy="6" rx="8" ry="3" />
-      <path d="M4 6v6c0 1.7 3.6 3 8 3s8-1.3 8-3V6" />
-      <path d="M4 12v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6" />
-    </svg>
-  )
+const TRIGGER_ICON_BY_CURRENCY: Record<SupportedCurrencyCode, LucideIcon> = {
+  EUR: Euro,
+  USD: DollarSign,
+  GBP: PoundSterling,
+  PLN: Coins,
+  CHF: SwissFranc,
+}
+
+function SelectedCurrencyIcon({ code }: { code: SupportedCurrencyCode }) {
+  const Icon = TRIGGER_ICON_BY_CURRENCY[code]
+  return <Icon aria-hidden className="lp-currency-trigger-icon" size={15} strokeWidth={2} />
 }
 
 export type CurrencyButtonBehavior = 'refresh' | 'rerun-search'
@@ -42,7 +46,7 @@ export default function CurrencyButton({
   const router = useRouter()
   const [current, setCurrent] = useState<SupportedCurrencyCode>('EUR')
   const [open, setOpen] = useState(false)
-  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null)
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null)
   const wrapRef = useRef<HTMLDivElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
@@ -63,29 +67,76 @@ export default function CurrencyButton({
     return () => window.removeEventListener(CURRENCY_CHANGE_EVENT, onChange)
   }, [])
 
-  const updateMenuPosition = () => {
-    const btn = buttonRef.current
-    if (!btn) return
-    const r = btn.getBoundingClientRect()
-    setMenuPos({ top: r.bottom + 8, right: Math.max(8, window.innerWidth - r.right) })
-  }
-
   useLayoutEffect(() => {
     if (!open) {
       setMenuPos(null)
       return
     }
+
+    function updateMenuPosition() {
+      const button = buttonRef.current
+      const menu = menuRef.current
+      if (!button || !menu) return
+
+      const gap = 8
+      const viewportPadding = 8
+      const rect = button.getBoundingClientRect()
+      const menuWidth = menu.offsetWidth || 168
+      const menuHeight = menu.offsetHeight || 0
+
+      let left = rect.right - menuWidth
+      left = Math.min(left, window.innerWidth - menuWidth - viewportPadding)
+      left = Math.max(viewportPadding, left)
+
+      let top = rect.bottom + gap
+      const aboveTop = rect.top - menuHeight - gap
+      if (menuHeight > 0 && top + menuHeight > window.innerHeight - viewportPadding && aboveTop >= viewportPadding) {
+        top = aboveTop
+      }
+
+      top = Math.max(viewportPadding, top)
+
+      setMenuPos({ top, left })
+    }
+
+    let frameId: number | null = null
+    const scheduleMenuPosition = () => {
+      if (frameId !== null) return
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null
+        updateMenuPosition()
+      })
+    }
+
     updateMenuPosition()
-    window.addEventListener('resize', updateMenuPosition)
-    return () => window.removeEventListener('resize', updateMenuPosition)
+
+    window.addEventListener('resize', scheduleMenuPosition)
+    window.addEventListener('scroll', scheduleMenuPosition, true)
+    window.visualViewport?.addEventListener('resize', scheduleMenuPosition)
+    window.visualViewport?.addEventListener('scroll', scheduleMenuPosition)
+
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId)
+      }
+      window.removeEventListener('resize', scheduleMenuPosition)
+      window.removeEventListener('scroll', scheduleMenuPosition, true)
+      window.visualViewport?.removeEventListener('resize', scheduleMenuPosition)
+      window.visualViewport?.removeEventListener('scroll', scheduleMenuPosition)
+    }
   }, [open])
 
   useEffect(() => {
     if (!open) return
     function onPointerDown(e: PointerEvent) {
-      const t = e.target as Node
-      if (wrapRef.current?.contains(t)) return
-      if (menuRef.current?.contains(t)) return
+      const target = e.target as Node
+      if (
+        wrapRef.current?.contains(target) ||
+        menuRef.current?.contains(target)
+      ) {
+        return
+      }
+
       setOpen(false)
     }
     document.addEventListener('pointerdown', onPointerDown)
@@ -116,39 +167,41 @@ export default function CurrencyButton({
     router.refresh()
   }
 
-  const dropdown =
-    open &&
-    menuPos &&
-    typeof document !== 'undefined' &&
-    createPortal(
-      <div
-        ref={menuRef}
-        className="lp-lang-dropdown lp-lang-dropdown--portal"
-        style={{ top: menuPos.top, right: menuPos.right }}
-        role="listbox"
-        aria-label="Select currency"
-      >
-        {DISPLAY_CURRENCIES.map((row) => (
-          <button
-            key={row.code}
-            role="option"
-            aria-selected={row.code === current}
-            className={`lp-lang-option${row.code === current ? ' lp-lang-option--active' : ''}`}
-            type="button"
-            onClick={() => persistAndNavigate(row.code)}
-          >
-            <span className="lp-lang-flag" aria-hidden="true">{row.code}</span>
-            <span className="lp-lang-name">{row.label}</span>
-            {row.code === current && (
-              <svg className="lp-lang-check" viewBox="0 0 16 16" fill="currentColor" width="13" height="13" aria-hidden="true">
-                <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/>
-              </svg>
-            )}
-          </button>
-        ))}
-      </div>,
-      document.body
-    )
+  const dropdown = open
+    ? createPortal(
+        <div
+          ref={menuRef}
+          className="lp-lang-dropdown lp-lang-dropdown--portal"
+          role="listbox"
+          aria-label="Select currency"
+          style={{
+            top: menuPos?.top ?? 0,
+            left: menuPos?.left ?? 0,
+            visibility: menuPos ? 'visible' : 'hidden',
+          }}
+        >
+          {DISPLAY_CURRENCIES.map((row) => (
+            <button
+              key={row.code}
+              role="option"
+              aria-selected={row.code === current}
+              className={`lp-lang-option${row.code === current ? ' lp-lang-option--active' : ''}`}
+              type="button"
+              onClick={() => persistAndNavigate(row.code)}
+            >
+              <span className="lp-lang-flag" aria-hidden="true">{row.code}</span>
+              <span className="lp-lang-name">{row.label}</span>
+              {row.code === current && (
+                <svg className="lp-lang-check" viewBox="0 0 16 16" fill="currentColor" width="13" height="13" aria-hidden="true">
+                  <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/>
+                </svg>
+              )}
+            </button>
+          ))}
+        </div>,
+        document.body,
+      )
+    : null
 
   return (
     <div ref={wrapRef} className={`lp-globe-wrap${inline ? ' lp-globe-wrap--inline' : ''}`}>
@@ -162,7 +215,7 @@ export default function CurrencyButton({
         onClick={() => setOpen((v) => !v)}
       >
         <span className="lp-currency-btn-inner" aria-hidden="true">
-          <CoinsIcon />
+          <SelectedCurrencyIcon code={current} />
           <span className="lp-currency-btn-code">{current}</span>
         </span>
       </button>

--- a/website/app/currency-button.tsx
+++ b/website/app/currency-button.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useRouter } from 'next/navigation'
+import {
+  CURRENCY_CHANGE_EVENT,
+  DISPLAY_CURRENCIES,
+  LETSFG_CURRENCY_COOKIE,
+  normalizeCurrencyCode,
+  readBrowserCurrencyPreference,
+  type SupportedCurrencyCode,
+} from '../lib/currency-preference'
+import { getTrackedSourcePath } from '../lib/probe-mode'
+
+function CoinsIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <ellipse cx="12" cy="6" rx="8" ry="3" />
+      <path d="M4 6v6c0 1.7 3.6 3 8 3s8-1.3 8-3V6" />
+      <path d="M4 12v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6" />
+    </svg>
+  )
+}
+
+export type CurrencyButtonBehavior = 'refresh' | 'rerun-search'
+
+export interface CurrencyButtonProps {
+  inline?: boolean
+  behavior: CurrencyButtonBehavior
+  /** Natural-language query — required for rerun-search when non-empty */
+  searchQuery?: string
+  probeMode?: boolean
+}
+
+export default function CurrencyButton({
+  inline = false,
+  behavior,
+  searchQuery = '',
+  probeMode = false,
+}: CurrencyButtonProps) {
+  const router = useRouter()
+  const [current, setCurrent] = useState<SupportedCurrencyCode>('EUR')
+  const [open, setOpen] = useState(false)
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    const params = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '')
+    const fromUrl = normalizeCurrencyCode(params.get('cur'))
+    if (fromUrl) {
+      document.cookie = `${LETSFG_CURRENCY_COOKIE}=${encodeURIComponent(fromUrl)}; path=/; max-age=31536000; SameSite=Lax`
+      setCurrent(fromUrl)
+      window.dispatchEvent(new CustomEvent(CURRENCY_CHANGE_EVENT))
+    } else {
+      setCurrent(readBrowserCurrencyPreference())
+    }
+
+    const onChange = () => setCurrent(readBrowserCurrencyPreference())
+    window.addEventListener(CURRENCY_CHANGE_EVENT, onChange)
+    return () => window.removeEventListener(CURRENCY_CHANGE_EVENT, onChange)
+  }, [])
+
+  const updateMenuPosition = () => {
+    const btn = buttonRef.current
+    if (!btn) return
+    const r = btn.getBoundingClientRect()
+    setMenuPos({ top: r.bottom + 8, right: Math.max(8, window.innerWidth - r.right) })
+  }
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setMenuPos(null)
+      return
+    }
+    updateMenuPosition()
+    window.addEventListener('resize', updateMenuPosition)
+    return () => window.removeEventListener('resize', updateMenuPosition)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    function onPointerDown(e: PointerEvent) {
+      const t = e.target as Node
+      if (wrapRef.current?.contains(t)) return
+      if (menuRef.current?.contains(t)) return
+      setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open])
+
+  const persistAndNavigate = (code: SupportedCurrencyCode) => {
+    document.cookie = `${LETSFG_CURRENCY_COOKIE}=${encodeURIComponent(code)}; path=/; max-age=31536000; SameSite=Lax`
+    setCurrent(code)
+    window.dispatchEvent(new CustomEvent(CURRENCY_CHANGE_EVENT))
+    setOpen(false)
+
+    if (behavior === 'rerun-search' && searchQuery.trim()) {
+      const path = `/results?q=${encodeURIComponent(searchQuery.trim())}&cur=${encodeURIComponent(code)}`
+      router.push(getTrackedSourcePath(path, probeMode))
+      return
+    }
+
+    router.refresh()
+  }
+
+  const dropdown =
+    open &&
+    menuPos &&
+    typeof document !== 'undefined' &&
+    createPortal(
+      <div
+        ref={menuRef}
+        className="lp-lang-dropdown lp-lang-dropdown--portal"
+        style={{ top: menuPos.top, right: menuPos.right }}
+        role="listbox"
+        aria-label="Select currency"
+      >
+        {DISPLAY_CURRENCIES.map((row) => (
+          <button
+            key={row.code}
+            role="option"
+            aria-selected={row.code === current}
+            className={`lp-lang-option${row.code === current ? ' lp-lang-option--active' : ''}`}
+            type="button"
+            onClick={() => persistAndNavigate(row.code)}
+          >
+            <span className="lp-lang-flag" aria-hidden="true">{row.code}</span>
+            <span className="lp-lang-name">{row.label}</span>
+            {row.code === current && (
+              <svg className="lp-lang-check" viewBox="0 0 16 16" fill="currentColor" width="13" height="13" aria-hidden="true">
+                <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/>
+              </svg>
+            )}
+          </button>
+        ))}
+      </div>,
+      document.body
+    )
+
+  return (
+    <div ref={wrapRef} className={`lp-globe-wrap${inline ? ' lp-globe-wrap--inline' : ''}`}>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`lp-globe-btn lp-currency-btn${open ? ' lp-globe-btn--open' : ''}`}
+        aria-label={`Currency: ${current}. Change currency`}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="lp-currency-btn-inner" aria-hidden="true">
+          <CoinsIcon />
+          <span className="lp-currency-btn-code">{current}</span>
+        </span>
+      </button>
+      {dropdown}
+    </div>
+  )
+}

--- a/website/app/currency-button.tsx
+++ b/website/app/currency-button.tsx
@@ -164,7 +164,11 @@ export default function CurrencyButton({
       return
     }
 
-    router.refresh()
+    const { pathname, search } = window.location
+    const params = new URLSearchParams(search)
+    params.set('cur', code)
+    const nextUrl = `${pathname}?${params.toString()}`
+    router.push(getTrackedSourcePath(nextUrl, probeMode))
   }
 
   const dropdown = open

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1526,6 +1526,10 @@ input {
   gap: 4px;
 }
 
+.lp-currency-trigger-icon {
+  flex-shrink: 0;
+}
+
 .lp-currency-btn-code {
   font-size: 10px;
   font-weight: 700;

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1514,6 +1514,25 @@ input {
   color: #fff;
 }
 
+.lp-currency-btn {
+  width: auto;
+  min-width: 44px;
+  padding: 0 8px;
+}
+
+.lp-currency-btn-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.lp-currency-btn-code {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1;
+}
+
 /* Language dropdown */
 
 .lp-globe-wrap {
@@ -2888,6 +2907,20 @@ body:has(.res-page) {
 
 .res-topbar-actions .lp-globe-btn:hover,
 .res-topbar-actions .lp-globe-btn--open {
+  background: rgba(255, 255, 255, 0.22);
+  border-color: rgba(255, 255, 255, 0.42);
+  color: #ffffff;
+}
+
+.res-topbar-actions .lp-currency-btn {
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 10px 24px rgba(20, 53, 76, 0.14);
+}
+
+.res-topbar-actions .lp-currency-btn:hover,
+.res-topbar-actions .lp-currency-btn.lp-globe-btn--open {
   background: rgba(255, 255, 255, 0.22);
   border-color: rgba(255, 255, 255, 0.42);
   color: #ffffff;

--- a/website/app/home-search-form.tsx
+++ b/website/app/home-search-form.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useState, useRef, useEffect, KeyboardEvent } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { findBestMatch, getAirportName, normalizeForSearch, AIRPORTS, Airport } from './airports'
+import { CURRENCY_CHANGE_EVENT, readBrowserCurrencyPreference, type SupportedCurrencyCode } from '../lib/currency-preference'
 
 const DESTINATION_KEYS = [
   { key: 'barcelona', code: 'BCN', flag: '/flags/es.svg', img: '/destinations/barcelona.jpg' },
@@ -505,6 +506,7 @@ export default function HomeSearchForm({
   const [query, setQuery] = useState(initialQuery)
   const [suggestion, setSuggestion] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [prefCurrency, setPrefCurrency] = useState<SupportedCurrencyCode>('EUR')
   const inputRef = useRef<HTMLInputElement>(null)
   const rowRef = useRef<HTMLDivElement>(null)
 
@@ -557,6 +559,13 @@ export default function HomeSearchForm({
     setQuery(initialQuery)
   }, [initialQuery])
 
+  useEffect(() => {
+    setPrefCurrency(readBrowserCurrencyPreference())
+    const sync = () => setPrefCurrency(readBrowserCurrencyPreference())
+    window.addEventListener(CURRENCY_CHANGE_EVENT, sync)
+    return () => window.removeEventListener(CURRENCY_CHANGE_EVENT, sync)
+  }, [])
+
   const handleSearch = (event: FormEvent) => {
     if (!query.trim()) {
       event.preventDefault()
@@ -606,6 +615,7 @@ export default function HomeSearchForm({
 
       <form action="/results" method="get" onSubmit={handleSearch} className="lp-sf-form">
         {probeMode && <input type="hidden" name="probe" value="1" />}
+        <input type="hidden" name="cur" value={prefCurrency} readOnly aria-hidden="true" />
         <div className="lp-sf-frame">
           <div className="lp-sf-input-wrap">
             <span className="lp-sf-leading" aria-hidden="true">

--- a/website/app/results/ResultsSearchForm.tsx
+++ b/website/app/results/ResultsSearchForm.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { trackSearchSessionEvent } from '../../lib/search-session-analytics'
+import { CURRENCY_CHANGE_EVENT, readBrowserCurrencyPreference, type SupportedCurrencyCode } from '../../lib/currency-preference'
 
 const DEMO_LOADING = false
 
@@ -41,10 +42,18 @@ export default function ResultsSearchForm({
   const router = useRouter()
   const [query, setQuery] = useState(initialQuery)
   const [isLoading, setIsLoading] = useState(false)
+  const [prefCurrency, setPrefCurrency] = useState<SupportedCurrencyCode>('EUR')
 
   useEffect(() => {
     setQuery(initialQuery)
   }, [initialQuery])
+
+  useEffect(() => {
+    setPrefCurrency(readBrowserCurrencyPreference())
+    const sync = () => setPrefCurrency(readBrowserCurrencyPreference())
+    window.addEventListener(CURRENCY_CHANGE_EVENT, sync)
+    return () => window.removeEventListener(CURRENCY_CHANGE_EVENT, sync)
+  }, [])
 
   const handleSearch = (event: FormEvent) => {
     if (!query.trim()) {
@@ -70,6 +79,7 @@ export default function ResultsSearchForm({
     <div className="lp-sf-wrap lp-sf-wrap--compact lp-sf-wrap--results">
       <form action="/results" method="get" onSubmit={handleSearch} className="lp-sf-form">
         {probeMode && <input type="hidden" name="probe" value="1" />}
+        <input type="hidden" name="cur" value={prefCurrency} readOnly aria-hidden="true" />
         <div className="lp-sf-frame">
           <div className="lp-sf-input-wrap">
             <span className="lp-sf-leading" aria-hidden="true">

--- a/website/app/results/[searchId]/SearchPageClient.tsx
+++ b/website/app/results/[searchId]/SearchPageClient.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import Image from 'next/image'
 import GlobeButton from '../../globe-button'
+import CurrencyButton from '../../currency-button'
 import ResultsSearchForm from '../ResultsSearchForm'
 import ResultsPanel from './ResultsPanel'
 import { trackSearchSessionEvent } from '../../../lib/search-session-analytics'
@@ -350,6 +351,7 @@ export default function SearchPageClient({
 
             <div className="res-topbar-actions">
               <GlobeButton inline />
+              <CurrencyButton inline behavior="rerun-search" searchQuery={query} probeMode={isTestSearch} />
               <a
                 href={REPO_URL}
                 target="_blank"

--- a/website/app/results/[searchId]/loading.tsx
+++ b/website/app/results/[searchId]/loading.tsx
@@ -5,6 +5,7 @@ import { useParams, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
 import GlobeButton from '../../globe-button'
+import CurrencyButton from '../../currency-button'
 import ResultsSearchForm from '../ResultsSearchForm'
 import SearchingTasks from './SearchingTasks'
 
@@ -83,6 +84,7 @@ function LoadingInner() {
             </Link>
             <div className="res-topbar-actions">
               <GlobeButton inline />
+              <CurrencyButton inline behavior="refresh" />
             </div>
           </div>
           <div className="res-search-shell">

--- a/website/app/results/loading.tsx
+++ b/website/app/results/loading.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
 import GlobeButton from '../globe-button'
+import CurrencyButton from '../currency-button'
 import ResultsSearchForm from './ResultsSearchForm'
 import SearchingTasks from './[searchId]/SearchingTasks'
 import { parseNLQuery } from '../lib/searchParsing'
@@ -28,6 +29,7 @@ function LoadingInner() {
             </Link>
             <div className="res-topbar-actions">
               <GlobeButton inline />
+              <CurrencyButton inline behavior="rerun-search" searchQuery={query} />
             </div>
           </div>
           <div className="res-search-shell">

--- a/website/app/results/page.tsx
+++ b/website/app/results/page.tsx
@@ -1,8 +1,11 @@
 import { Suspense } from 'react'
+import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
 import GlobeButton from '../globe-button'
+import CurrencyButton from '../currency-button'
+import { LETSFG_CURRENCY_COOKIE, resolveSearchCurrency, type SupportedCurrencyCode } from '../../lib/currency-preference'
 import ResultsSearchForm from './ResultsSearchForm'
 import ResultsPanel from './[searchId]/ResultsPanel'
 import SearchingTasks from './[searchId]/SearchingTasks'
@@ -256,8 +259,9 @@ function normalizeOffer(raw: RawOffer, idx: number) {
 
 async function startFSWSearch(
   parsed: ReturnType<typeof parseNLQuery>,
-  query?: string,
-  isProbe = false,
+  query: string | undefined,
+  isProbe: boolean,
+  currency: SupportedCurrencyCode,
 ): Promise<{ searchId: string | null; cache: 'hit' | 'miss' }> {
   if (!parsed.origin || !parsed.destination || !parsed.date) {
     return { searchId: null, cache: 'miss' }
@@ -324,6 +328,7 @@ async function PageTopbar({ query, homeHref = '/en' }: { query: string; homeHref
       </Link>
       <div className="res-topbar-actions">
         <GlobeButton inline />
+        <CurrencyButton inline behavior="refresh" />
         <a href={REPO_URL} target="_blank" rel="noreferrer" className={stars !== null ? 'res-icon-btn res-icon-btn--gh' : 'res-icon-btn'} aria-label="GitHub" title="GitHub">
           <GitHubIcon />
           {stars !== null && <span className="res-gh-stars"><span className="res-gh-star" aria-hidden="true">⭐</span>{formatStars(stars)}</span>}
@@ -354,7 +359,19 @@ function PageFooter() {
 
 // ── Main async search component (runs server-side) ────────────────────────────
 
-async function SearchContent({ query, sid, started, isProbe }: { query: string; sid?: string; started?: string; isProbe: boolean }) {
+async function SearchContent({
+  query,
+  sid,
+  started,
+  isProbe,
+  currency,
+}: {
+  query: string
+  sid?: string
+  started?: string
+  isProbe: boolean
+  currency: SupportedCurrencyCode
+}) {
   const parsed = parseNLQuery(query)
   const routeLabel = [
     parsed.origin_name || parsed.origin,
@@ -408,7 +425,7 @@ async function SearchContent({ query, sid, started, isProbe }: { query: string; 
       )
     }
 
-    const fswResult = await startFSWSearch(parsed, query, isProbe)
+    const fswResult = await startFSWSearch(parsed, query, isProbe, currency)
     searchId = fswResult.searchId ?? undefined
     cacheHit = fswResult.cache === 'hit'
     if (!searchId) {
@@ -465,6 +482,7 @@ function SearchFallback({ query, isProbe }: { query: string; isProbe: boolean })
             </Link>
             <div className="res-topbar-actions">
               <GlobeButton inline />
+              <CurrencyButton inline behavior="refresh" />
             </div>
           </div>
           <div className="res-search-shell">
@@ -500,10 +518,15 @@ export async function generateMetadata({ searchParams }: { searchParams: Promise
 export default async function ResultsQueryPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; sid?: string; started?: string; probe?: string }>
+  searchParams: Promise<{ q?: string; sid?: string; started?: string; probe?: string; cur?: string }>
 }) {
-  const { q, sid, started, probe } = await searchParams
+  const { q, sid, started, probe, cur } = await searchParams
   const isProbe = isProbeModeValue(probe)
+  const cookieStore = await cookies()
+  const resolvedCurrency = resolveSearchCurrency({
+    queryParam: cur?.trim(),
+    cookieValue: cookieStore.get(LETSFG_CURRENCY_COOKIE)?.value,
+  })
 
   if (!q?.trim()) {
     redirect(isProbe ? '/en?probe=1' : '/')
@@ -513,7 +536,13 @@ export default async function ResultsQueryPage({
 
   return (
     <Suspense fallback={<SearchFallback query={query} isProbe={isProbe} />}>
-      <SearchContent query={query} sid={sid?.trim()} started={started?.trim()} isProbe={isProbe} />
+      <SearchContent
+        query={query}
+        sid={sid?.trim()}
+        started={started?.trim()}
+        isProbe={isProbe}
+        currency={resolvedCurrency}
+      />
     </Suspense>
   )
 }

--- a/website/app/results/page.tsx
+++ b/website/app/results/page.tsx
@@ -16,8 +16,6 @@ import { startWebSearch } from '../../lib/fsw-search'
 import { upsertSearchSessionServer } from '../../lib/search-session-analytics-server'
 import { getGitHubStars, formatStars } from '../../lib/github-stars'
 import { getTrackedSourcePath, isProbeModeValue } from '../../lib/probe-mode'
-import { detectPreferredCurrency } from '../../lib/user-currency'
-import { headers } from 'next/headers'
 
 const FSW_SECRET = process.env.FSW_SECRET || ''
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://letsfg.co'
@@ -268,14 +266,13 @@ async function startFSWSearch(
   }
 
   try {
-    const requestHeaders = await headers()
     const result = await startWebSearch({
       origin: parsed.origin,
       destination: parsed.destination,
       date_from: parsed.date,
       return_date: parsed.return_date || undefined,
       adults: 1,
-      currency: detectPreferredCurrency(requestHeaders),
+      currency,
       ...(parsed.stops !== undefined ? { max_stops: parsed.stops } : {}),
       ...(parsed.cabin ? { cabin: parsed.cabin } : {}),
     }, {

--- a/website/lib/currency-preference.ts
+++ b/website/lib/currency-preference.ts
@@ -1,0 +1,43 @@
+/** Cookie storing preferred ISO 4217 code for new flight searches (website UI). */
+export const LETSFG_CURRENCY_COOKIE = 'LETSFG_CURRENCY'
+
+export const DEFAULT_SEARCH_CURRENCY = 'EUR'
+
+export const DISPLAY_CURRENCIES = [
+  { code: 'EUR', label: 'Euro' },
+  { code: 'USD', label: 'US Dollar' },
+  { code: 'GBP', label: 'British Pound' },
+  { code: 'PLN', label: 'Polish Złoty' },
+  { code: 'CHF', label: 'Swiss Franc' },
+] as const
+
+export type SupportedCurrencyCode = (typeof DISPLAY_CURRENCIES)[number]['code']
+
+const ALLOWED = new Set<string>(DISPLAY_CURRENCIES.map((c) => c.code))
+
+/** Broadcast after the cookie is updated so forms can sync hidden fields without a full reload. */
+export const CURRENCY_CHANGE_EVENT = 'letsfg-currency-change'
+
+export function normalizeCurrencyCode(raw: string | undefined | null): SupportedCurrencyCode | null {
+  if (!raw || typeof raw !== 'string') return null
+  const u = raw.trim().toUpperCase()
+  return ALLOWED.has(u) ? (u as SupportedCurrencyCode) : null
+}
+
+export function resolveSearchCurrency(input: {
+  queryParam?: string | null
+  cookieValue?: string | null
+}): SupportedCurrencyCode {
+  const fromQuery = normalizeCurrencyCode(input.queryParam ?? undefined)
+  if (fromQuery) return fromQuery
+  const fromCookie = normalizeCurrencyCode(input.cookieValue ?? undefined)
+  if (fromCookie) return fromCookie
+  return DEFAULT_SEARCH_CURRENCY
+}
+
+export function readBrowserCurrencyPreference(): SupportedCurrencyCode {
+  if (typeof document === 'undefined') return DEFAULT_SEARCH_CURRENCY
+  const m = document.cookie.match(new RegExp(`(?:^|;\\s*)${LETSFG_CURRENCY_COOKIE}=([^;]*)`))
+  const raw = m?.[1] ? decodeURIComponent(m[1].trim()) : ''
+  return normalizeCurrencyCode(raw) ?? DEFAULT_SEARCH_CURRENCY
+}

--- a/website/lib/currency-preference.ts
+++ b/website/lib/currency-preference.ts
@@ -35,9 +35,17 @@ export function resolveSearchCurrency(input: {
   return DEFAULT_SEARCH_CURRENCY
 }
 
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return ''
+  }
+}
+
 export function readBrowserCurrencyPreference(): SupportedCurrencyCode {
   if (typeof document === 'undefined') return DEFAULT_SEARCH_CURRENCY
   const m = document.cookie.match(new RegExp(`(?:^|;\\s*)${LETSFG_CURRENCY_COOKIE}=([^;]*)`))
-  const raw = m?.[1] ? decodeURIComponent(m[1].trim()) : ''
+  const raw = m?.[1] ? safeDecodeURIComponent(m[1].trim()) : ''
   return normalizeCurrencyCode(raw) ?? DEFAULT_SEARCH_CURRENCY
 }


### PR DESCRIPTION
## Summary

Adds a persistent currency preference to the website's flight search,
letting users pick the display/search currency from the home page and
results page search forms. Selection is stored in a `LETSFG_CURRENCY`
cookie and forwarded to searches via a `cur` query param so it survives
navigation and is shareable via link.

Supported currencies today: EUR (default), USD, GBP, PLN, CHF.

Closes https://github.com/LetsFG/LetsFG/issues/121

## Changes

- New `currency-button` component rendered in the home and results
  search forms, with a custom icon per supported currency.
- New `lib/currency-preference.ts` helper that resolves the active code
  from query string → cookie → default, with a safe cookie decoder that
  tolerates malformed values.
- Search forms append `?cur=<code>` to the results URL when a currency
  is selected; the results page reads the same param.

Commits are kept granular for review:

1. **Add currency selector to website search forms** — cookie, helper,
   component, wiring into search forms.
2. **Render distinct icons per currency in the selector** — visual
   polish for the dropdown.
3. **Forward selected currency to search via `cur` query param** —
   makes navigation/sharing stable.
4. **Guard currency cookie decoding against malformed values** —
   defensive `decodeURIComponent` wrapper.

## Test plan

- [ ] Load the home page; confirm the currency button defaults to EUR.
- [ ] Change currency on the home form, run a search, and verify the
      results URL contains `cur=<code>` and the page renders prices in
      that currency.
- [ ] Change currency on the results page; the next search keeps the
      selection.
- [ ] Reload — the cookie persists the selection across sessions.
- [ ] Manually set `document.cookie = "LETSFG_CURRENCY=%E0"` and reload;
      page should fall back to EUR rather than throw.
- [ ] Visit a results URL with `?cur=GBP` directly; results render in
      GBP regardless of cookie.

## Notes

- No backend changes; all logic is client-side under `website/`.
- Diff is identical in content to the squashed feature work; commits
  rebased clean on top of `main`.