### PR TITLE
chore: exclude growth-ops backend from public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ Thumbs.db
 .idea/
 site/
 
+# Backend service — lives in LetsFG/LetsFG-private (security-sensitive)
+growth-ops/
+
 # Diagnostic probe directories (debug artifacts)
 .*_diag*/
 .*_probe*/


### PR DESCRIPTION
## Summary

Adds `growth-ops/` to `.gitignore` to permanently prevent the backend service from ever being committed to this public repository.

## Why

The Growth Ops Engine is a Node.js backend service that contains:
- Firebase service account credentials
- Telegram bot token & chat configuration
- Gemini AI API key references
- Internal analytics API integration
- Proprietary business logic (hypothesis generation, experiment management)

It lives in **LetsFG/LetsFG-private** instead.

## Changes
- `.gitignore` — added `growth-ops/` entry with explanatory comment