### PR TITLE
feat(cli): add --country and --region filters to flight search

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -23,6 +23,13 @@ letsfg search-local LHR BCN 2026-06-15
 
 That fires 200 airline connectors on your machine. **Free. Unlimited. Zero setup.**
 
+```bash
+# Search using only Brazilian sites
+letsfg search BSB SDU 2026-05-24 --country BR
+# Or by region
+letsfg search GRU LIM 2026-06-15 --region latin-america
+```
+
 **Short on time?** Use `--mode fast` to search only OTAs + key airlines (~25 connectors, 20-40s instead of 6+ min):
 
 ```bash

--- a/sdk/python/letsfg/cli.py
+++ b/sdk/python/letsfg/cli.py
@@ -33,6 +33,7 @@ except ImportError:
 
 from letsfg.client import LetsFG, LetsFGError, AuthenticationError
 from letsfg.connectors.currency import fetch_rates, _fallback_convert
+from letsfg.connectors.source_regions import REGIONS, resolve_country_filter
 
 app = typer.Typer(
     name="letsfg",
@@ -348,6 +349,9 @@ def search(
     direct: bool = typer.Option(False, "--direct", "-d", help="Direct flights only (shortcut for --max-stops 0)"),
     max_browsers: Optional[int] = typer.Option(None, "--max-browsers", "-b", help="Max concurrent browsers (1-32, default: auto-detect from RAM)"),
     mode: Optional[str] = typer.Option(None, "--mode", "-m", help="Search mode: 'fast' (OTAs + key airlines, 20-40s) or default (all 200+ connectors)"),
+    country: Optional[list[str]] = typer.Option(None, "--country", "-C", help="Filter sources to ISO country code(s), comma-separated or repeated (e.g. BR or BR,AR)"),
+    region: Optional[str] = typer.Option(None, "--region", help="Filter sources by predefined region"),
+    include_global: bool = typer.Option(False, "--include-global", help="Include global aggregators when a country/region filter is active"),
     output_json: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show pipeline diagnostics (per-source offer counts at each filter stage)"),
 ):
@@ -386,6 +390,10 @@ def search(
 
     # --direct is a shortcut for --max-stops 0
     effective_max_stops = 0 if direct else max_stops
+    try:
+        country_filter = resolve_country_filter(country, region)
+    except ValueError as e:
+        _err(f"{e} Valid regions: {', '.join(sorted(REGIONS))}.")
 
     async def _run():
         asyncio.get_event_loop().set_exception_handler(lambda loop, ctx: None)
@@ -402,6 +410,8 @@ def search(
             max_browsers=max_browsers,
             max_stopovers=effective_max_stops,
             mode=mode,
+            country_filter=country_filter,
+            include_global=include_global,
         )
 
     try:

--- a/sdk/python/letsfg/client.py
+++ b/sdk/python/letsfg/client.py
@@ -403,6 +403,8 @@ class LetsFG:
         currency: str = "EUR",
         limit: int = 50,
         max_browsers: int | None = None,
+        country_filter: frozenset[str] | set[str] | list[str] | None = None,
+        include_global: bool = False,
     ) -> FlightSearchResult:
         """
         Search flights using 73 local airline connectors — FREE, no API key needed.
@@ -422,6 +424,8 @@ class LetsFG:
             currency: 3-letter currency code
             limit: Max results (1-200)
             max_browsers: Max concurrent browser processes (1-32, default: auto-detect).
+            country_filter: ISO alpha-2 country codes used to filter source markets.
+            include_global: Include global aggregators when country_filter is active.
 
         Returns:
             FlightSearchResult with offers from local scrapers.
@@ -441,6 +445,8 @@ class LetsFG:
             currency=currency,
             limit=limit,
             max_browsers=max_browsers,
+            country_filter=country_filter,
+            include_global=include_global,
         ))
         return FlightSearchResult.from_dict(result_dict)
 

--- a/sdk/python/letsfg/connectors/engine.py
+++ b/sdk/python/letsfg/connectors/engine.py
@@ -244,6 +244,7 @@ from .starair import StarAirConnectorClient
 from .his import HISConnectorClient
 
 from ..models.flights import AirlineSummary, FlightOffer, FlightSearchRequest, FlightSearchResponse
+from .source_regions import REGIONS, passes_country_filter, route_touches_country
 
 logger = logging.getLogger(__name__)
 
@@ -891,6 +892,9 @@ class MultiProvider:
         if fast_mode:
             logger.info("Fast mode: using ~25 OTAs/metas/key LCCs instead of %d full connectors",
                         len(_DIRECT_AIRLINE_connectorS))
+        country_filter = req.country_filter
+        include_global = req.include_global
+        country_skipped = 0
         
         tasks = []
         providers_used = []
@@ -932,7 +936,8 @@ class MultiProvider:
         if ryanair_connector and (not fast_mode or "ryanair_direct" in _FAST_MODE_SOURCES) and (
                 not cabin_filter_active or "ryanair_direct" not in _ECONOMY_ONLY_SOURCES) and (
                 not origin_country or not dest_country or not ryanair_countries
-                or (origin_country in ryanair_countries and dest_country in ryanair_countries)):
+                or (origin_country in ryanair_countries and dest_country in ryanair_countries)) and (
+                passes_country_filter("ryanair_direct", req.origin, req.destination, country_filter, include_global)):
             tasks.append(self._search_ryanair_direct(ryanair_connector, req))
             providers_used.append("ryanair_direct")
 
@@ -941,12 +946,14 @@ class MultiProvider:
         if _BROWSERS_AVAILABLE and wizzair_connector and (not fast_mode or "wizzair_direct" in _FAST_MODE_SOURCES) and (
                 not cabin_filter_active or "wizzair_direct" not in _ECONOMY_ONLY_SOURCES) and (
                 not origin_country or not dest_country or not wizz_countries
-                or (origin_country in wizz_countries and dest_country in wizz_countries)):
+                or (origin_country in wizz_countries and dest_country in wizz_countries)) and (
+                passes_country_filter("wizzair_direct", req.origin, req.destination, country_filter, include_global)):
             tasks.append(self._search_wizzair_direct(wizzair_connector, req))
             providers_used.append("wizzair_direct")
 
         # Kiwi is a global aggregator — always query it (always in fast mode set)
-        if kiwi_connector and (not fast_mode or "kiwi_connector" in _FAST_MODE_SOURCES):
+        if kiwi_connector and (not fast_mode or "kiwi_connector" in _FAST_MODE_SOURCES) and (
+                passes_country_filter("kiwi_connector", req.origin, req.destination, country_filter, include_global)):
             tasks.append(self._search_kiwi_connector(kiwi_connector, req))
             providers_used.append("kiwi_connector")
 
@@ -987,6 +994,22 @@ class MultiProvider:
             logger.info("Fast mode: filtered to %d/%d connectors",
                         len(filtered_connectors), before_fast)
 
+        if country_filter is not None:
+            before_country = len(filtered_connectors)
+            filtered_connectors = [
+                (src, cls, t) for src, cls, t in filtered_connectors
+                if passes_country_filter(src, req.origin, req.destination, country_filter, include_global)
+            ]
+            country_skipped = before_country - len(filtered_connectors)
+            if country_skipped:
+                logger.info("Country filter: skipped %d/%d connectors for country=%s include_global=%s",
+                            country_skipped, before_country, sorted(country_filter), include_global)
+
+        has_special_country_source = any(
+            provider in {"ryanair_direct", "wizzair_direct", "kiwi_connector"}
+            for provider in providers_used
+        )
+
         # Skip browser-based connectors when Chrome is not available
         # (cloud/agent environments). API-only connectors still run.
         browser_skipped = 0
@@ -1001,6 +1024,15 @@ class MultiProvider:
                 logger.info("No browser available — skipped %d browser-based connectors "
                             "(API-only connectors + Kiwi aggregator still active)",
                             browser_skipped)
+
+        if country_filter is not None and not self.backend_available and not has_special_country_source and not filtered_connectors:
+            valid_regions = ", ".join(sorted(REGIONS))
+            raise ValueError(
+                "No local sources matched country filter "
+                f"{sorted(country_filter)} for route {req.origin}->{req.destination}; "
+                f"{country_skipped} sources were removed. "
+                f"Try --include-global or a different --region. Valid regions: {valid_regions}."
+            )
 
         skipped = len(_DIRECT_AIRLINE_connectorS) - len(filtered_connectors)
         if skipped - browser_skipped > 0:
@@ -1065,6 +1097,8 @@ class MultiProvider:
                 # Skip economy-only connectors when cabin filter is active
                 if cabin_filter_active and label in _ECONOMY_ONLY_SOURCES:
                     continue
+                if not passes_country_filter(label, req.origin, req.destination, country_filter, include_global):
+                    continue
                 client_out = getter()
                 client_ret = getter()
                 if client_out:
@@ -1096,6 +1130,11 @@ class MultiProvider:
                 return_filtered = [
                     (s, c, t) for s, c, t in return_filtered
                     if s not in _ECONOMY_ONLY_SOURCES
+                ]
+            if country_filter is not None:
+                return_filtered = [
+                    (s, c, t) for s, c, t in return_filtered
+                    if passes_country_filter(s, return_req.origin, return_req.destination, country_filter, include_global)
                 ]
             # Skip browser connectors when Chrome is not available (same as outbound)
             if not _BROWSERS_AVAILABLE:
@@ -1224,6 +1263,17 @@ class MultiProvider:
                 failed.append(provider)
                 continue
             if isinstance(result, FlightSearchResponse):
+                if provider == "backend" and country_filter is not None:
+                    before_backend_country = len(result.offers)
+                    result.offers = [
+                        offer for offer in result.offers
+                        if self._offer_route_touches_country(offer, req, country_filter)
+                    ]
+                    result.total_results = len(result.offers)
+                    backend_country_skipped = before_backend_country - len(result.offers)
+                    if backend_country_skipped:
+                        logger.info("Country filter: removed %d backend offers for country=%s",
+                                    backend_country_skipped, sorted(country_filter))
                 if result.offers:
                     succeeded.append(f"{provider}({len(result.offers)})")
                 else:
@@ -1470,6 +1520,19 @@ class MultiProvider:
             search_params={},
             source_tiers=source_tiers,
         )
+
+    @staticmethod
+    def _offer_route_touches_country(
+        offer: FlightOffer,
+        req: FlightSearchRequest,
+        country_filter: frozenset[str],
+    ) -> bool:
+        """Backend offers are filtered by displayed route endpoints only."""
+        if offer.outbound and offer.outbound.segments:
+            first = offer.outbound.segments[0]
+            last = offer.outbound.segments[-1]
+            return route_touches_country(first.origin, last.destination, country_filter)
+        return route_touches_country(req.origin, req.destination, country_filter)
 
     # ── Telemetry: report connector health to backend ────────────────────────
 

--- a/sdk/python/letsfg/connectors/source_regions.py
+++ b/sdk/python/letsfg/connectors/source_regions.py
@@ -1,0 +1,167 @@
+"""Country and region filters for local flight-search sources."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Optional
+
+from .airline_routes import AIRLINE_COUNTRIES, get_country
+
+
+GLOBAL_AGGREGATORS = frozenset({
+    "kiwi_connector",
+    "skyscanner_meta",
+    "kayak_meta",
+    "momondo_meta",
+    "skiplagged_meta",
+    "aviasales_meta",
+    "wego_meta",
+    "cheapflights_meta",
+    "agoda_meta",
+    "ixigo_meta",
+})
+
+EXEMPT_SOURCES = frozenset({
+    "aircairo_direct",
+    "hkexpress_direct",
+    "serpapi_google",
+})
+
+REGIONS = {
+    "latin-america": frozenset({"AR", "BR", "CL", "CO", "PE", "MX", "UY", "EC", "BO", "PY", "VE", "DO", "PA", "CR", "GT", "HN", "NI", "SV", "JM", "CU"}),
+    "eu": frozenset({"AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE", "GB", "CH", "NO", "IS"}),
+    "mena": frozenset({"AE", "SA", "KW", "QA", "BH", "OM", "JO", "LB", "EG", "MA", "TN", "DZ", "IL", "TR"}),
+    "asia": frozenset({"CN", "HK", "TW", "JP", "KR", "SG", "MY", "TH", "VN", "PH", "ID", "IN", "BD", "PK", "LK", "MM", "KH", "LA", "MO"}),
+    "africa": frozenset({"ZA", "KE", "ET", "NG", "GH", "TZ", "UG", "RW", "MA", "EG", "TN", "DZ", "SN", "CI"}),
+    "north-america": frozenset({"US", "CA", "MX"}),
+    "oceania": frozenset({"AU", "NZ", "FJ", "PG", "VU", "SB", "WS", "TO"}),
+}
+
+_TIER2 = {
+    "despegar_ota": {"AR", "BR", "MX", "CL", "CO", "PE", "UY", "EC", "BO", "PY", "VE", "US"},
+    "tripcom_ota": {"CN", "HK", "TW", "SG", "MY", "ID", "TH", "VN", "PH", "JP", "KR", "AE", "AU", "GB", "US", "FR", "DE", "IT", "ES", "BR", "MX"},
+    "easemytrip_ota": {"IN", "AE", "US", "GB", "SG", "AU"},
+    "almosafer_ota": {"SA", "AE", "KW", "QA", "BH", "OM", "EG", "JO"},
+    "yatra_ota": {"IN"},
+    "cleartrip_ota": {"IN", "AE", "SA", "KW", "QA", "BH", "OM"},
+    "akbartravels_ota": {"IN", "AE"},
+    "musafir_ota": {"AE", "IN", "SA"},
+    "rehlat_ota": {"AE", "SA", "KW", "QA"},
+    "traveloka_ota": {"ID", "TH", "VN", "PH", "MY", "SG", "AU"},
+    "tiket_ota": {"ID"},
+    "webjet_ota": {"AU", "NZ"},
+    "auntbetty_ota": {"AU", "NZ"},
+    "byojet_ota": {"AU", "NZ"},
+    "flightcatchers_ota": {"GB"},
+    "traveltrolley_ota": {"GB"},
+    "travelup_ota": {"GB"},
+    "lastminute_ota": {"GB", "IT", "ES", "FR", "DE", "NL", "IE", "BE"},
+    "opodo_ota": {"GB", "FR", "DE", "IT", "ES", "SE", "NL", "PL"},
+    "edreams_ota": {"ES", "IT", "FR", "GB", "DE", "PT", "AT", "CH", "NL", "BE", "SE", "DK", "FI", "NO", "PL"},
+    "etraveli_ota": {"SE", "NO", "DK", "FI", "DE", "GB", "FR"},
+    "esky_ota": {"PL", "CZ", "HU", "SK", "RO"},
+    "bookingcom_ota": {"NL", "GB", "US", "FR", "DE", "IT", "ES", "BR", "MX", "JP", "CN", "IN", "AU"},
+    "airasiamove_ota": {"MY", "TH", "ID", "PH", "SG", "VN"},
+    "his_ota": {"JP"},
+}
+
+
+def _build_connector_countries() -> dict[str, frozenset[str]]:
+    countries: dict[str, frozenset[str]] = {
+        f"{airline_key}_direct": frozenset(values)
+        for airline_key, values in AIRLINE_COUNTRIES.items()
+    }
+    if "wizz" in AIRLINE_COUNTRIES:
+        countries["wizzair_direct"] = frozenset(AIRLINE_COUNTRIES["wizz"])
+    for airline_key, values in AIRLINE_COUNTRIES.items():
+        for suffix in ("_api", "_calendar", "_scraper", "_ota", "_meta", "_connector"):
+            countries.setdefault(f"{airline_key}{suffix}", frozenset(values))
+    countries.update({source_id: frozenset(values) for source_id, values in _TIER2.items()})
+    # Global aggregators are a disjoint category — opt-in via --include-global.
+    # Strip them from the country map so the default filter excludes them.
+    for source_id in GLOBAL_AGGREGATORS:
+        countries.pop(source_id, None)
+    return countries
+
+
+CONNECTOR_COUNTRIES = _build_connector_countries()
+
+
+def normalize_country_codes(values: Iterable[str]) -> frozenset[str]:
+    """Normalize repeated or comma-separated ISO alpha-2 country values."""
+    codes: set[str] = set()
+    for value in values:
+        for part in str(value).split(","):
+            code = part.strip().upper()
+            if not code:
+                continue
+            if not re.fullmatch(r"[A-Z]{2}", code):
+                raise ValueError(f"Invalid country code '{part.strip()}'. Use ISO alpha-2 codes like BR or US.")
+            codes.add(code)
+    if not codes:
+        raise ValueError("At least one country code is required.")
+    return frozenset(codes)
+
+
+def resolve_country_filter(
+    country: Optional[Iterable[str]],
+    region: Optional[str],
+) -> Optional[frozenset[str]]:
+    """Combine explicit country codes and a predefined region into one filter."""
+    if country is None and region is None:
+        return None
+
+    selected: set[str] = set()
+    if country is not None:
+        selected.update(normalize_country_codes(country))
+
+    if region is not None:
+        region_key = region.strip().lower()
+        if region_key not in REGIONS:
+            valid = ", ".join(sorted(REGIONS))
+            raise ValueError(f"Unknown region '{region}'. Valid regions: {valid}.")
+        selected.update(REGIONS[region_key])
+
+    return frozenset(selected)
+
+
+def route_touches_country(origin: str, dest: str, country_filter: frozenset[str]) -> bool:
+    """Return True when either endpoint country matches, failing open for unknown endpoints."""
+    origin_country = get_country(origin)
+    dest_country = get_country(dest)
+    if origin_country is None or dest_country is None:
+        return True
+    return origin_country in country_filter or dest_country in country_filter
+
+
+def connector_matches_market(
+    source_id: str,
+    country_filter: Optional[frozenset[str]],
+    include_global: bool,
+) -> bool:
+    """Return True when the source market overlaps the active country filter."""
+    if country_filter is None:
+        return True
+    if source_id in GLOBAL_AGGREGATORS:
+        return include_global
+    source_countries = CONNECTOR_COUNTRIES.get(source_id)
+    if source_countries is None:
+        return False
+    return bool(source_countries & country_filter)
+
+
+def passes_country_filter(
+    source_id: str,
+    origin: str,
+    dest: str,
+    country_filter: Optional[frozenset[str]],
+    include_global: bool,
+) -> bool:
+    """Apply source-market and endpoint-country semantics together."""
+    if country_filter is None:
+        return True
+    return (
+        connector_matches_market(source_id, country_filter, include_global)
+        and route_touches_country(origin, dest, country_filter)
+    )

--- a/sdk/python/letsfg/local.py
+++ b/sdk/python/letsfg/local.py
@@ -58,6 +58,8 @@ async def search_local(
     max_browsers: int | None = None,
     max_stopovers: int | None = None,
     mode: str | None = None,
+    country_filter: frozenset[str] | set[str] | list[str] | None = None,
+    include_global: bool = False,
 ) -> dict:
     """
     Run all 73 local airline connectors and return results as a dict.
@@ -92,6 +94,8 @@ async def search_local(
         currency=currency,
         limit=limit,
         max_stopovers=max_stopovers if max_stopovers is not None else 2,
+        country_filter=country_filter,
+        include_global=include_global,
     )
 
     resp = await multi_provider.search_flights(req, mode=mode)
@@ -562,6 +566,8 @@ def _main() -> None:
             limit=params.get("limit", 50),
             max_browsers=params.get("max_browsers"),
             mode=params.get("mode"),
+            country_filter=params.get("country_filter"),
+            include_global=params.get("include_global", False),
         )
 
     try:

--- a/sdk/python/letsfg/models/flights.py
+++ b/sdk/python/letsfg/models/flights.py
@@ -100,6 +100,21 @@ class FlightSearchRequest(BaseModel):
         default_factory=dict,
         description="Provider-specific filter payloads keyed by provider name, e.g. {'google_flights': {...}}",
     )
+    country_filter: Optional[frozenset[str]] = Field(
+        default=None,
+        description="ISO alpha-2 countries used to filter source markets and route endpoints",
+    )
+    include_global: bool = Field(
+        False,
+        description="Include global aggregators when country_filter is active",
+    )
+
+    @field_validator("country_filter", mode="before")
+    @classmethod
+    def validate_country_filter(cls, v: Any) -> Optional[frozenset[str]]:
+        if v is None:
+            return None
+        return frozenset(str(code).strip().upper() for code in v if str(code).strip())
 
     @field_validator("origin", "destination")
     @classmethod

--- a/sdk/python/tests/test_country_filter_completeness.py
+++ b/sdk/python/tests/test_country_filter_completeness.py
@@ -1,0 +1,26 @@
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SDK_PYTHON_ROOT = PROJECT_ROOT / "sdk" / "python"
+if str(SDK_PYTHON_ROOT) not in sys.path:
+    sys.path.insert(0, str(SDK_PYTHON_ROOT))
+
+from letsfg.connectors.engine import _DIRECT_AIRLINE_connectorS
+from letsfg.connectors.source_regions import (
+    CONNECTOR_COUNTRIES,
+    EXEMPT_SOURCES,
+    GLOBAL_AGGREGATORS,
+)
+
+
+class CountryFilterCompletenessTest(unittest.TestCase):
+    def test_all_registered_sources_are_classified_global_or_exempt(self):
+        covered = set(CONNECTOR_COUNTRIES) | set(GLOBAL_AGGREGATORS) | set(EXEMPT_SOURCES)
+        missing = sorted(source_id for source_id, _, _ in _DIRECT_AIRLINE_connectorS if source_id not in covered)
+        self.assertEqual(missing, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/test_source_country_filter.py
+++ b/sdk/python/tests/test_source_country_filter.py
@@ -1,0 +1,100 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SDK_PYTHON_ROOT = PROJECT_ROOT / "sdk" / "python"
+if str(SDK_PYTHON_ROOT) not in sys.path:
+    sys.path.insert(0, str(SDK_PYTHON_ROOT))
+
+from letsfg.cli import app
+from letsfg.connectors.source_regions import (
+    REGIONS,
+    connector_matches_market,
+    normalize_country_codes,
+    passes_country_filter,
+    resolve_country_filter,
+    route_touches_country,
+)
+
+
+class SourceCountryFilterHelpersTest(unittest.TestCase):
+    def test_normalize_country_codes_accepts_repeated_and_comma_values(self):
+        self.assertEqual(
+            normalize_country_codes(["br, ar", "mx"]),
+            frozenset({"BR", "AR", "MX"}),
+        )
+
+    def test_normalize_country_codes_rejects_non_iso_alpha2_values(self):
+        with self.assertRaisesRegex(ValueError, "Invalid country code"):
+            normalize_country_codes(["BRA"])
+
+    def test_resolve_country_filter_combines_country_and_region(self):
+        result = resolve_country_filter(["BR"], "north-america")
+        self.assertIn("BR", result)
+        self.assertIn("US", result)
+        self.assertIn("CA", result)
+
+    def test_resolve_country_filter_unknown_region_lists_valid_regions(self):
+        with self.assertRaisesRegex(ValueError, "Valid regions"):
+            resolve_country_filter(None, "antarctica")
+
+    def test_route_touches_country_matches_origin_or_destination_only(self):
+        countries = frozenset({"BR"})
+        self.assertTrue(route_touches_country("BSB", "SDU", countries))
+        self.assertFalse(route_touches_country("SCL", "PUQ", countries))
+
+    def test_route_touches_country_fails_open_for_unknown_endpoint(self):
+        self.assertTrue(route_touches_country("ZZZ", "PUQ", frozenset({"BR"})))
+
+    def test_connector_market_matches_country_footprint(self):
+        self.assertTrue(connector_matches_market("gol_direct", frozenset({"BR"}), False))
+        self.assertFalse(connector_matches_market("gol_direct", frozenset({"GB"}), False))
+
+    def test_global_aggregators_are_opt_in(self):
+        countries = frozenset({"BR"})
+        self.assertFalse(connector_matches_market("kiwi_connector", countries, False))
+        self.assertTrue(connector_matches_market("kiwi_connector", countries, True))
+
+    def test_passes_country_filter_requires_market_and_route(self):
+        countries = frozenset({"BR"})
+        self.assertTrue(passes_country_filter("latam_direct", "GRU", "LIM", countries, False))
+        self.assertFalse(passes_country_filter("latam_direct", "SCL", "PUQ", countries, False))
+
+    def test_regions_contract_contains_expected_predefined_region(self):
+        self.assertIn("latin-america", REGIONS)
+        self.assertIn("BR", REGIONS["latin-america"])
+
+
+class SourceCountryFilterCliTest(unittest.TestCase):
+    def test_cli_resolves_country_filter_before_search_local(self):
+        runner = CliRunner()
+
+        async def fake_search_local(**kwargs):
+            self.assertEqual(kwargs["country_filter"], frozenset({"BR", "AR"}))
+            self.assertTrue(kwargs["include_global"])
+            return {"total_results": 0, "offers": []}
+
+        with patch("letsfg.local.search_local", fake_search_local):
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "BSB",
+                    "SDU",
+                    "2026-05-24",
+                    "--country",
+                    "br,ar",
+                    "--include-global",
+                    "--json",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add `--country` and `--region` flags to `letsfg search` so users can restrict the search to connectors serving a particular country or region. Useful when you only want results from sites that operate in your market (e.g. `--country BR` returns flights from GOL, Azul, LATAM, Decolar, Trip.com BR — not every site on earth).

```bash
# Single country
letsfg search BSB SDU 2026-05-24 --country BR

# Multiple countries (comma list OR repeated flag)
letsfg search BSB SDU 2026-05-24 --country BR,AR

# Named region
letsfg search GRU LIM 2026-06-15 --region latin-america

# Combine with fast mode (intersection)
letsfg search BSB SDU 2026-05-24 --country BR --mode fast

# Opt into global aggregators (Kiwi/Skyscanner/Momondo/…)
letsfg search BSB SDU 2026-05-24 --country BR --include-global
```

## Design

**Filter semantic = source-market ∩ route-touches-country (origin OR destination).** A connector is kept if:
1. It serves at least one country in the filter (source-market), AND
2. The route's origin or destination country is in the filter (route-touches-country).

Both checks together kill the surprise where, say, `letsfg search SCL PUQ --country BR` would still include `latam_direct` (Chile→Chile route) just because LATAM serves the Brazilian market.

Global aggregators (Kiwi, Skyscanner, Momondo, Kayak, Cheapflights, Aviasales, Wego, Agoda, Skiplagged, Ixigo) are gated behind `--include-global` — opt-in keeps the filter meaning what it says.

Empty intersection hard-fails before any HTTP or browser launch, with a diagnostic listing valid regions and suggesting `--include-global`.

## Architecture

| File | Change |
|------|--------|
| `connectors/source_regions.py` *(new)* | `CONNECTOR_COUNTRIES` registry, `REGIONS` presets, `GLOBAL_AGGREGATORS` set, `normalize_country_codes()`, `resolve_country_filter()`, `route_touches_country()`, `connector_matches_market()`, `passes_country_filter()` |
| `connectors/engine.py` | Applies filter in: main connector list, special ryanair/wizzair/kiwi gates, combo round-trip return legs, combo special connectors; post-filters backend offers by route-touches-country (backend has no country API param) |
| `models/flights.py` | `FlightSearchRequest.country_filter`, `include_global` |
| `cli.py` / `local.py` / `client.py` | Thread the two fields through; CLI validates input before reaching engine |
| `tests/test_source_country_filter.py` *(new)* | 11 tests: helpers, region resolution, CLI propagation, route-touches edge cases, SCL→PUQ semantic |
| `tests/test_country_filter_completeness.py` *(new)* | Registry-completeness test — every active connector source ID must be in `CONNECTOR_COUNTRIES`, `GLOBAL_AGGREGATORS`, or `EXEMPT_SOURCES`. Fails CI when new connectors land without a country mapping. |

## Coverage strategy

`CONNECTOR_COUNTRIES` is populated in two tiers:
- **Tier 1 (~160 sources, auto-derived)**: for each `airline_key` in `AIRLINE_COUNTRIES`, register `f"{airline_key}_direct"` → that airline's country set. Plus `_api`/`_calendar`/`_scraper`/`_ota`/`_meta`/`_connector` suffix variants for the same key.
- **Tier 2 (~25 sources, manually curated)**: OTAs and metas where the source ID doesn't share a key with `AIRLINE_COUNTRIES` (despegar_ota, tripcom_ota, easemytrip_ota, almosafer_ota, traveloka_ota, lastminute_ota, edreams_ota, etc.) — populated from public knowledge of each site's market footprint.
- **Global aggregators**: not in `CONNECTOR_COUNTRIES`; only in `GLOBAL_AGGREGATORS`. Opt-in via `--include-global`.

## JS SDK / MCP

Both `sdk/js` and `sdk/mcp` spawn `python -m letsfg.local` as a subprocess and pipe JSON over stdin/stdout. The Python side's JSON params (`local.py:_run`) reads `country_filter` and `include_global` via `params.get()` with defaults, so JS/MCP work backward-compat today. A follow-up PR can expose the new options at the JS/MCP layer; nothing is required for parity.

## Backend

The Cloud Run backend (`api.letsfg.co/api/v1/flights/search`) takes no country parameter, so we cannot pre-filter server-side. Backend offers are post-filtered by route-touches-country only (using `offer.outbound.segments[0].origin` and `[-1].destination`). Source-market filter doesn't apply to backend offers because their `source` IDs are server-generated and not in the local registry. This preserves GDS/full-service coverage when a country filter is active.

## Test plan

- [x] `python -m pytest sdk/python/tests/test_source_country_filter.py tests/test_country_filter_completeness.py -v` → **12 passed**
- [x] Full suite: `python -m pytest sdk/python/tests/ --tb=no -q` → **110 passed, 5 failed** (5 failures are pre-existing in `test_ancillary_connector_parsing.py` and unrelated to this PR)
- [x] Smoke test 1: `letsfg search BSB SDU 2026-05-24 --country BR --currency BRL` → returns gol_direct, latam_direct, tripcom_ota, hopper_direct (all serve BR); no global aggregators
- [x] Smoke test 2: `letsfg search SCL PUQ 2026-05-24 --country BR` → hard-fails with `"No local sources matched country filter ['BR'] for route SCL->PUQ; N sources were removed. Try --include-global or a different --region."`
- [x] Smoke test 3: `--country BR --include-global` → adds momondo_meta, skiplagged_meta to results

## Backwards compatibility

All new flags default to `None`/`False`. Existing CLI/SDK invocations unchanged. JS/MCP subprocess JSON protocol unchanged (new fields are optional `params.get()` reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)