### PR TITLE
fix(tests): add committed fixtures for ancillary connector parsing — unblocks Tier-1 CI gate

### DIFF
--- a/sdk/python/tests/fixtures/_airasiax_KUL-NRT_profile=d.json
+++ b/sdk/python/tests/fixtures/_airasiax_KUL-NRT_profile=d.json
@@ -1,0 +1,45 @@
+{
+  "searchResults": {
+    "trips": [
+      {
+        "flightsList": [
+          {
+            "convertedPrice": 350.0,
+            "userCurrencyCode": "MYR",
+            "tripId": "KUL-NRT-fixture",
+            "flightDetails": {
+              "designator": {
+                "carrierCode": "D7",
+                "departureStation": "KUL",
+                "arrivalStation": "NRT",
+                "departureTime": "2026-07-01T08:00:00",
+                "arrivalTime": "2026-07-01T16:00:00"
+              },
+              "segments": [
+                {
+                  "carrierCode": "D7",
+                  "marketingFlightNo": "D7511",
+                  "designator": {
+                    "departureStation": "KUL",
+                    "arrivalStation": "NRT",
+                    "departureTime": "2026-07-01T08:00:00",
+                    "arrivalTime": "2026-07-01T16:00:00"
+                  }
+                }
+              ],
+              "baggage": {
+                "complimentaryBaggage": [
+                  {
+                    "type": "cabin_bag",
+                    "weight": 7
+                  }
+                ],
+                "checkedBaggageAllowed": true
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/sdk/python/tests/fixtures/_mea_air_bounds.json
+++ b/sdk/python/tests/fixtures/_mea_air_bounds.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "airBoundGroups": [
+      {
+        "boundDetails": {
+          "duration": 14400,
+          "segments": [{ "flightId": "ME201" }]
+        },
+        "airBounds": [
+          {
+            "fareFamilyCode": "ECOFLEX",
+            "prices": { "totalPrices": [{ "total": 18900, "currencyCode": "USD" }] },
+            "availabilityDetails": [{ "flightId": "ME201", "cabin": "economy" }],
+            "services": [{ "serviceCode": "SVC_ECO" }]
+          },
+          {
+            "fareFamilyCode": "BUSIFLEX",
+            "prices": { "totalPrices": [{ "total": 45000, "currencyCode": "USD" }] },
+            "availabilityDetails": [{ "flightId": "ME201", "cabin": "business" }],
+            "services": [{ "serviceCode": "SVC_BUSI" }]
+          }
+        ]
+      }
+    ]
+  },
+  "dictionaries": {
+    "flight": {
+      "ME201": {
+        "departure": { "locationCode": "BEY", "dateTime": "2026-06-10T08:00:00" },
+        "arrival": { "locationCode": "CDG", "dateTime": "2026-06-10T11:30:00" },
+        "marketingAirlineCode": "ME",
+        "marketingFlightNumber": "201"
+      }
+    },
+    "currency": { "USD": { "decimalPlaces": 2 } },
+    "fareFamilyWithServices": {
+      "ECOFLEX": { "cabin": "economy" },
+      "BUSIFLEX": { "cabin": "business" }
+    },
+    "service": {
+      "SVC_ECO": {
+        "serviceType": "freeCheckedBaggage",
+        "baggagePolicyDescriptions": [
+          {
+            "quantity": 1,
+            "baggageCharacteristics": [
+              {
+                "policyDetails": [
+                  { "type": "weight", "unit": "kilogram", "value": 23 }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "SVC_BUSI": {
+        "serviceType": "freeCheckedBaggage",
+        "baggagePolicyDescriptions": [
+          {
+            "quantity": 2,
+            "baggageCharacteristics": [
+              {
+                "policyDetails": [
+                  { "type": "weight", "unit": "kilogram", "value": 30 }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/sdk/python/tests/fixtures/_tmp_aircairo_air_bounds.json
+++ b/sdk/python/tests/fixtures/_tmp_aircairo_air_bounds.json
@@ -1,0 +1,84 @@
+{
+  "data": {
+    "airBoundGroups": [
+      {
+        "boundDetails": {
+          "duration": 8100,
+          "segments": [{ "flightId": "SM601" }]
+        },
+        "airBounds": [
+          {
+            "fareFamilyCode": "PROMO",
+            "airOffer": { "totalPrice": { "value": "99.00", "currencyCode": "USD" } },
+            "services": [{ "serviceCode": "BAG30KG" }],
+            "fareConditionsCodes": ["RC_NREF"],
+            "availabilityDetails": [{ "flightId": "SM601", "cabin": "economy" }]
+          },
+          {
+            "fareFamilyCode": "SPECIAL",
+            "airOffer": { "totalPrice": { "value": "129.00", "currencyCode": "USD" } },
+            "services": [{ "serviceCode": "BAG30KG" }],
+            "fareConditionsCodes": ["RC_NREF"],
+            "availabilityDetails": [{ "flightId": "SM601", "cabin": "economy" }]
+          },
+          {
+            "fareFamilyCode": "ECONOMY",
+            "airOffer": { "totalPrice": { "value": "159.00", "currencyCode": "USD" } },
+            "services": [{ "serviceCode": "BAG30KG" }],
+            "fareConditionsCodes": ["RC_FEE"],
+            "availabilityDetails": [{ "flightId": "SM601", "cabin": "economy" }]
+          },
+          {
+            "fareFamilyCode": "ECO FLEX",
+            "airOffer": { "totalPrice": { "value": "199.00", "currencyCode": "USD" } },
+            "services": [{ "serviceCode": "BAG30KG" }],
+            "fareConditionsCodes": ["RC_FEE"],
+            "availabilityDetails": [{ "flightId": "SM601", "cabin": "economy" }]
+          }
+        ]
+      }
+    ]
+  },
+  "dictionaries": {
+    "flight": {
+      "SM601": {
+        "marketingAirlineCode": "SM",
+        "marketingFlightNumber": "601",
+        "departure": { "locationCode": "CAI", "dateTime": "2026-04-21T06:00:00" },
+        "arrival": { "locationCode": "JED", "dateTime": "2026-04-21T08:15:00" }
+      }
+    },
+    "currency": {
+      "USD": { "decimalPlaces": 0 }
+    },
+    "fareFamilyWithServices": {
+      "PROMO": { "cabin": "economy" },
+      "SPECIAL": { "cabin": "economy" },
+      "ECONOMY": { "cabin": "economy" },
+      "ECO FLEX": { "cabin": "economy" }
+    },
+    "service": {
+      "BAG30KG": {
+        "serviceType": "freeCheckedBaggage",
+        "baggagePolicyDescriptions": [
+          { "type": "weight", "quantity": 30, "weightUnit": "kilogram" }
+        ]
+      }
+    },
+    "fareConditions": {
+      "RC_NREF": {
+        "category": "refund",
+        "details": [{ "isAllowed": false }]
+      },
+      "RC_FEE": {
+        "category": "refund",
+        "details": [
+          {
+            "isAllowed": true,
+            "penalty": { "price": { "total": "50.00", "currencyCode": "USD" } }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/sdk/python/tests/fixtures/aireuropa_mad_bcn.json
+++ b/sdk/python/tests/fixtures/aireuropa_mad_bcn.json
@@ -1,0 +1,56 @@
+{
+  "data": {
+    "airBoundGroups": [
+      {
+        "boundDetails": {
+          "duration": 5400,
+          "segments": [{ "flightId": "UX1001" }]
+        },
+        "airBounds": [
+          {
+            "fareFamilyCode": "NOBAG",
+            "prices": { "totalPrices": [{ "total": 5900, "currencyCode": "EUR" }] },
+            "availabilityDetails": [{ "flightId": "UX1001", "cabin": "economy" }]
+          },
+          {
+            "fareFamilyCode": "ECONOMY",
+            "prices": { "totalPrices": [{ "total": 8900, "currencyCode": "EUR" }] },
+            "availabilityDetails": [{ "flightId": "UX1001", "cabin": "economy" }]
+          },
+          {
+            "fareFamilyCode": "FLEX",
+            "prices": { "totalPrices": [{ "total": 12900, "currencyCode": "EUR" }] },
+            "availabilityDetails": [{ "flightId": "UX1001", "cabin": "economy" }]
+          },
+          {
+            "fareFamilyCode": "BUSINESS",
+            "prices": { "totalPrices": [{ "total": 22900, "currencyCode": "EUR" }] },
+            "availabilityDetails": [{ "flightId": "UX1001", "cabin": "business" }]
+          },
+          {
+            "fareFamilyCode": "BUSFLEX",
+            "prices": { "totalPrices": [{ "total": 28900, "currencyCode": "EUR" }] },
+            "availabilityDetails": [{ "flightId": "UX1001", "cabin": "business" }]
+          }
+        ]
+      }
+    ]
+  },
+  "dictionaries": {
+    "flight": {
+      "UX1001": {
+        "departure": { "locationCode": "MAD", "dateTime": "2026-06-10T07:00:00" },
+        "arrival": { "locationCode": "BCN", "dateTime": "2026-06-10T08:30:00" },
+        "marketingAirlineCode": "UX",
+        "marketingFlightNumber": "1001"
+      }
+    },
+    "fareFamilyWithServices": {
+      "NOBAG":    { "cabin": "economy" },
+      "ECONOMY":  { "cabin": "economy" },
+      "FLEX":     { "cabin": "economy" },
+      "BUSINESS": { "cabin": "business" },
+      "BUSFLEX":  { "cabin": "business" }
+    }
+  }
+}

--- a/sdk/python/tests/fixtures/webcon-backup/_ita_api_51.json
+++ b/sdk/python/tests/fixtures/webcon-backup/_ita_api_51.json
@@ -1,0 +1,74 @@
+{
+  "data": {
+    "airBoundGroups": [
+      {
+        "boundDetails": {
+          "originLocationCode": "FCO",
+          "destinationLocationCode": "LHR",
+          "duration": 9000,
+          "segments": [{ "flightId": "AZ201" }]
+        },
+        "airBounds": [
+          {
+            "fareFamilyCode": "ECONOMY",
+            "airOffer": { "totalPrice": { "value": 18500, "currencyCode": "EUR" } },
+            "availabilityDetails": [{ "flightId": "AZ201", "cabin": "economy" }],
+            "services": [
+              { "serviceCode": "C0CCC1", "price": { "total": 7000, "currencyCode": "EUR" } },
+              { "serviceCode": "A0B5X",  "price": { "total": 1500, "currencyCode": "EUR" } }
+            ],
+            "fareConditionsCodes": []
+          },
+          {
+            "fareFamilyCode": "FLEX",
+            "airOffer": { "totalPrice": { "value": 32000, "currencyCode": "EUR" } },
+            "availabilityDetails": [{ "flightId": "AZ201", "cabin": "economy" }],
+            "services": [
+              { "serviceCode": "FBA23" }
+            ],
+            "fareConditionsCodes": []
+          }
+        ]
+      }
+    ]
+  },
+  "dictionaries": {
+    "flight": {
+      "AZ201": {
+        "departure": { "locationCode": "FCO", "dateTime": "2026-06-10T09:00:00" },
+        "arrival": { "locationCode": "LHR", "dateTime": "2026-06-10T11:15:00" },
+        "marketingAirlineCode": "AZ",
+        "marketingFlightNumber": "201"
+      }
+    },
+    "airline": { "AZ": "ITA Airways" },
+    "currency": { "EUR": { "decimalPlaces": 2 } },
+    "fareFamilyWithServices": {
+      "ECONOMY": { "cabin": "economy", "services": [] },
+      "FLEX":    { "cabin": "economy", "services": [] }
+    },
+    "service": {
+      "C0CCC1": {
+        "serviceDescriptions": [{ "content": "FIRST CHECKED BAG" }]
+      },
+      "A0B5X": {
+        "serviceDescriptions": [{ "content": "Standard seat" }]
+      },
+      "FBA23": {
+        "baggagePolicyDescriptions": [
+          {
+            "quantity": 1,
+            "baggageCharacteristics": [
+              {
+                "policyDetails": [
+                  { "type": "weight", "unit": "kilogram", "value": 23 }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "fareConditions": {}
+  }
+}

--- a/sdk/python/tests/test_ancillary_connector_parsing.py
+++ b/sdk/python/tests/test_ancillary_connector_parsing.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 SDK_PYTHON_ROOT = PROJECT_ROOT / "sdk" / "python"
-WORKSPACE_ROOT = PROJECT_ROOT.parent
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
 if str(SDK_PYTHON_ROOT) not in sys.path:
     sys.path.insert(0, str(SDK_PYTHON_ROOT))
 
@@ -152,7 +152,7 @@ class AncillaryConnectorParsingTest(unittest.TestCase):
         self.assertEqual(merged.get("inbound_checked_bag"), "included - 1 piece 20kg checked bag")
 
     def test_airasiax_parser_reads_saved_baggage_truth_from_response(self) -> None:
-        payload = json.loads((WORKSPACE_ROOT / "_airasiax_KUL-NRT_profile=d.json").read_text(encoding="utf-8"))
+        payload = json.loads((FIXTURES / "_airasiax_KUL-NRT_profile=d.json").read_text(encoding="utf-8"))
         req = FlightSearchRequest(origin="KUL", destination="NRT", date_from=_future_date(34), adults=1, currency="USD")
 
         client = AirAsiaXConnectorClient()
@@ -170,7 +170,7 @@ class AncillaryConnectorParsingTest(unittest.TestCase):
         self.assertFalse((offer.bags_price or {}).get("seat_selection"))
 
     def test_ita_parser_exposes_fare_family_ancillaries(self) -> None:
-        payload = json.loads((WORKSPACE_ROOT / "webcon-backup" / "_ita_api_51.json").read_text(encoding="utf-8"))
+        payload = json.loads((FIXTURES / "webcon-backup" / "_ita_api_51.json").read_text(encoding="utf-8"))
         req = FlightSearchRequest(origin="FCO", destination="LHR", date_from=_future_date(35), adults=1)
 
         client = ITAAirwaysConnectorClient()
@@ -192,7 +192,7 @@ class AncillaryConnectorParsingTest(unittest.TestCase):
         self.assertEqual(rt_offer.bags_price.get("inbound_checked_bag"), 0.0)
 
     def test_mea_parser_keeps_all_fare_families_and_bags(self) -> None:
-        payload = json.loads((WORKSPACE_ROOT / "_mea_air_bounds.json").read_text(encoding="utf-8"))
+        payload = json.loads((FIXTURES / "_mea_air_bounds.json").read_text(encoding="utf-8"))
         req = FlightSearchRequest(origin="BEY", destination="CDG", date_from=_future_date(45), adults=1)
 
         client = MEAConnectorClient()
@@ -213,7 +213,7 @@ class AncillaryConnectorParsingTest(unittest.TestCase):
         self.assertEqual(rt_offer.bags_price.get("checked_bag"), 0.0)
 
     def test_aircairo_parser_reads_airboundgroups_and_preserves_metadata(self) -> None:
-        payload = json.loads((WORKSPACE_ROOT / "_tmp_aircairo_air_bounds.json").read_text(encoding="utf-8"))
+        payload = json.loads((FIXTURES / "_tmp_aircairo_air_bounds.json").read_text(encoding="utf-8"))
         req = FlightSearchRequest.model_construct(
             origin="CAI",
             destination="JED",
@@ -244,7 +244,7 @@ class AncillaryConnectorParsingTest(unittest.TestCase):
         self.assertEqual(rt_offer.bags_price.get("checked_bag"), 0.0)
 
     def test_aireuropa_parser_only_flags_nobag(self) -> None:
-        payload = json.loads((WORKSPACE_ROOT / "_aireuropa_flight_data.json").read_text(encoding="utf-8"))
+        payload = json.loads((FIXTURES / "aireuropa_mad_bcn.json").read_text(encoding="utf-8"))
         req = FlightSearchRequest(origin="MAD", destination="BCN", date_from=_future_date(60), adults=1)
 
         client = AirEuropaConnectorClient()


### PR DESCRIPTION
## Summary

- The "Python deterministic tests (Tier-1, required)" CI check has been red since `test_ancillary_connector_parsing.py` was added. The 5 tests that call real connector parsers were loading fixture files from `WORKSPACE_ROOT` (parent of the repo), which doesn't exist in CI.
- This PR replaces `WORKSPACE_ROOT` with `FIXTURES = tests/fixtures/` and adds 5 synthetic but structurally accurate fixture files derived from each connector's actual parse path.

**Fixtures added:**
| File | Connector | Asserts |
|------|-----------|---------|
| `_airasiax_KUL-NRT_profile=d.json` | AirAsiaX | `source=airasiax_direct`, `owner_airline=D7`, cabin_bag 7kg, checked_bag not included |
| `_tmp_aircairo_air_bounds.json` | AirCairo | 4 fare families (PROMO/SPECIAL/ECONOMY/ECO FLEX), 30kg bag, refund conditions, round-trip merge |
| `_mea_air_bounds.json` | MEA | ECOFLEX 1×23kg / BUSIFLEX 2×30kg, bags_price=0.0 on both legs |
| `aireuropa_mad_bcn.json` | AirEuropa | 5 fare families, NOBAG="not included", others no checked_bag key |
| `webcon-backup/_ita_api_51.json` | ITA Airways | C0CCC1 paid bag 70€, A0B5X seat, FBA23 included bag, round-trip merge |

## Test plan
- [ ] "Python deterministic tests (Tier-1, required)" turns green
- [ ] All 193 deterministic tests pass (188 pre-existing + 5 previously-failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)