### PR TITLE
fix(proxy): IP-CIDR blocklist for path-scoped abuse defense

### DIFF
--- a/website/lib/ip-blocklist.ts
+++ b/website/lib/ip-blocklist.ts
@@ -1,0 +1,115 @@
+// IP-CIDR denylist for the proxy middleware. Used to drop traffic from known
+// abuse source ranges before any expensive work runs.
+//
+// Source intentionally contains NO default CIDRs. The actual list is sourced
+// at runtime from the LETSFG_BLOCKED_CIDRS env var (set on Cloud Run) so the
+// list can be tuned without a redeploy and isn't visible in this public repo
+// — listing a CIDR here is a free hint to a sophisticated attacker about
+// what to rotate away from. Same pattern as ua-blocklist.ts.
+//
+// Format: comma-separated IPv4 CIDRs.
+//   LETSFG_BLOCKED_CIDRS="1.2.3.0/24,4.5.0.0/16"
+//
+// With no env var set, no IP is blocked here (rely on UA blocklist +
+// rate-limit + Cloudflare WAF when CF is in the data path).
+//
+// Scope: callers decide which paths to apply this on via
+// pathIsAbuseProtected(). Some Google ranges overlap legitimate Googlebot
+// crawlers, so blocking globally would damage SEO indexing of marketing &
+// PFP pages — apply only to the expensive search endpoints.
+
+interface ParsedCidr {
+  base: number
+  mask: number
+}
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let n = 0
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null
+    const octet = Number(part)
+    if (octet < 0 || octet > 255) return null
+    n = n * 256 + octet
+  }
+  return n
+}
+
+function parseCidr(cidr: string): ParsedCidr | null {
+  const trimmed = cidr.trim()
+  if (!trimmed) return null
+  const [ipStr, prefixStr] = trimmed.split('/')
+  const ip = ipv4ToInt(ipStr || '')
+  const prefix = Number(prefixStr)
+  if (ip === null || !Number.isInteger(prefix) || prefix < 0 || prefix > 32) return null
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0
+  return { base: (ip & mask) >>> 0, mask }
+}
+
+function getCidrList(env: Record<string, string | undefined>): ReadonlyArray<ParsedCidr> {
+  const raw = env.LETSFG_BLOCKED_CIDRS
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean)
+    .map(parseCidr)
+    .filter((c): c is ParsedCidr => c !== null)
+}
+
+export function ipMatchesBlockedCidr(
+  ip: string,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const n = ipv4ToInt(ip)
+  if (n === null) return false
+  for (const { base, mask } of getCidrList(env)) {
+    if (((n & mask) >>> 0) === base) return true
+  }
+  return false
+}
+
+export function extractClientIp(headers: Headers): string | null {
+  // Leftmost X-Forwarded-For is the original client across all ingress paths:
+  // CF → Firebase → Cloud Run, Firebase → Cloud Run, direct .run.app.
+  const xff = headers.get('x-forwarded-for')
+  if (xff) {
+    const first = xff.split(',')[0]?.trim()
+    if (first) return stripPortAndBrackets(first)
+  }
+  const fallback = headers.get('cf-connecting-ip') || headers.get('x-real-ip')
+  return fallback ? stripPortAndBrackets(fallback) : null
+}
+
+function stripPortAndBrackets(raw: string): string {
+  let value = raw.trim()
+  if (value.startsWith('[')) {
+    const end = value.indexOf(']')
+    if (end > 0) return value.slice(1, end)
+  }
+  // IPv4 "1.2.3.4:5678" → strip port. IPv6 contains multiple colons; leave.
+  const colonCount = (value.match(/:/g) || []).length
+  if (colonCount === 1) value = value.split(':')[0]
+  return value
+}
+
+const ABUSE_PROTECTED_PREFIXES: ReadonlyArray<string> = [
+  '/results',
+  '/api/results',
+  '/api/search',
+  '/api/offer',
+]
+
+export function pathIsAbuseProtected(pathname: string): boolean {
+  for (const prefix of ABUSE_PROTECTED_PREFIXES) {
+    if (
+      pathname === prefix ||
+      pathname.startsWith(`${prefix}/`) ||
+      pathname.startsWith(`${prefix}?`)
+    ) {
+      return true
+    }
+  }
+  return false
+}

--- a/website/proxy.ts
+++ b/website/proxy.ts
@@ -11,6 +11,7 @@ import {
   getRateLimitPolicy,
 } from './lib/rate-limit'
 import { isBlockedUserAgent } from './lib/ua-blocklist'
+import { extractClientIp, ipMatchesBlockedCidr, pathIsAbuseProtected } from './lib/ip-blocklist'
 import { isPublicShareAssetPath } from './lib/share-preview'
 
 const intlMiddleware = createMiddleware(routing)
@@ -108,6 +109,20 @@ export default function proxy(req: NextRequest) {
       status: 403,
       headers: { 'Cache-Control': 'no-store' },
     })
+  }
+
+  // IP-range block scoped to expensive search endpoints. Defends against bots
+  // that rotate through Google Cloud NAT egress (defeating per-IP rate limits)
+  // and bypass Cloudflare by hitting the .run.app URL directly. Marketing &
+  // PFP paths stay reachable so legit Googlebot keeps indexing them.
+  if (pathIsAbuseProtected(pathname)) {
+    const clientIp = extractClientIp(req.headers)
+    if (clientIp && ipMatchesBlockedCidr(clientIp)) {
+      return new NextResponse('Forbidden', {
+        status: 403,
+        headers: { 'Cache-Control': 'no-store' },
+      })
+    }
   }
 
   const legacyDocsRedirect = redirectLegacyDocsHost(req)

--- a/website/tests/ip-blocklist.test.ts
+++ b/website/tests/ip-blocklist.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { extractClientIp, ipMatchesBlockedCidr, pathIsAbuseProtected } from '../lib/ip-blocklist'
+
+describe('ipMatchesBlockedCidr', () => {
+  it('blocks IPs in a CIDR provided via env var', () => {
+    const env = { LETSFG_BLOCKED_CIDRS: '10.0.0.0/8,192.168.1.0/24' }
+    assert.equal(ipMatchesBlockedCidr('10.5.6.7', env), true)
+    assert.equal(ipMatchesBlockedCidr('192.168.1.42', env), true)
+  })
+
+  it('does not block IPs outside the configured ranges', () => {
+    const env = { LETSFG_BLOCKED_CIDRS: '10.0.0.0/8' }
+    assert.equal(ipMatchesBlockedCidr('8.8.8.8', env), false)
+    assert.equal(ipMatchesBlockedCidr('192.168.1.1', env), false)
+  })
+
+  it('blocks nothing when env var is unset (no source defaults)', () => {
+    assert.equal(ipMatchesBlockedCidr('10.0.0.1', {}), false)
+    assert.equal(ipMatchesBlockedCidr('66.102.8.36', {}), false)
+  })
+
+  it('rejects malformed input safely', () => {
+    const env = { LETSFG_BLOCKED_CIDRS: '10.0.0.0/8' }
+    assert.equal(ipMatchesBlockedCidr('', env), false)
+    assert.equal(ipMatchesBlockedCidr('not-an-ip', env), false)
+    assert.equal(ipMatchesBlockedCidr('999.0.0.1', env), false)
+    assert.equal(ipMatchesBlockedCidr('10.0.0', env), false)
+  })
+
+  it('ignores malformed CIDRs in env var, applies valid ones', () => {
+    const env = { LETSFG_BLOCKED_CIDRS: 'garbage,10.0.0.0/8,also-garbage/99' }
+    assert.equal(ipMatchesBlockedCidr('10.1.2.3', env), true)
+    assert.equal(ipMatchesBlockedCidr('8.8.8.8', env), false)
+  })
+})
+
+describe('extractClientIp', () => {
+  it('takes the leftmost x-forwarded-for entry', () => {
+    const h = new Headers({ 'x-forwarded-for': '74.125.210.5, 169.254.1.1, 10.0.0.1' })
+    assert.equal(extractClientIp(h), '74.125.210.5')
+  })
+
+  it('strips IPv4 port suffix', () => {
+    const h = new Headers({ 'x-forwarded-for': '66.102.8.36:443' })
+    assert.equal(extractClientIp(h), '66.102.8.36')
+  })
+
+  it('falls back to cf-connecting-ip when xff absent', () => {
+    const h = new Headers({ 'cf-connecting-ip': '203.0.113.5' })
+    assert.equal(extractClientIp(h), '203.0.113.5')
+  })
+
+  it('returns null when no client headers present', () => {
+    assert.equal(extractClientIp(new Headers()), null)
+  })
+})
+
+describe('pathIsAbuseProtected', () => {
+  it('matches the expensive search paths', () => {
+    assert.equal(pathIsAbuseProtected('/results'), true)
+    assert.equal(pathIsAbuseProtected('/results/ws_abc123'), true)
+    assert.equal(pathIsAbuseProtected('/api/results/ws_abc123'), true)
+    assert.equal(pathIsAbuseProtected('/api/search'), true)
+    assert.equal(pathIsAbuseProtected('/api/offer/foo'), true)
+  })
+
+  it('does NOT match marketing or PFP paths (Googlebot can still crawl)', () => {
+    assert.equal(pathIsAbuseProtected('/'), false)
+    assert.equal(pathIsAbuseProtected('/en'), false)
+    assert.equal(pathIsAbuseProtected('/en/flights/poa-cun'), false)
+    assert.equal(pathIsAbuseProtected('/developers'), false)
+    assert.equal(pathIsAbuseProtected('/llms.txt'), false)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds env-var-driven IP-CIDR matcher in `proxy.ts` scoped to expensive search paths (`/results`, `/api/results`, `/api/search`, `/api/offer`)
- Marketing & PFP pages remain reachable so legitimate Googlebot keeps indexing them
- Defends against bots that rotate through many source IPs and bypass Cloudflare entirely by hitting the raw `.run.app` URL — neither per-IP rate limits nor CF WAF rules apply to that traffic pattern
- Source contains **no** default block list — actual CIDRs live in `LETSFG_BLOCKED_CIDRS` env var on Cloud Run, so this public repo doesn't broadcast what we detect (same convention as `ua-blocklist.ts`)

## Test plan

- [x] 11 unit tests in `tests/ip-blocklist.test.ts` — all pass
- [x] Typecheck clean
- [x] Verified in prod: bot UA → 403, Google NAT IP → 403, legit user → 200, Googlebot crawling `/en` → 200
- [x] Confirmed bot's search-attack rate dropped to 0 on expensive paths since deploy

## Follow-up (not in this PR)

- Cloud Run ingress lockdown (`--ingress=internal-and-cloud-load-balancing`) so `.run.app` stops accepting public traffic entirely