### PR TITLE
fix(proxy): Host-header allowlist — block direct .run.app access

### DIFF
--- a/website/lib/host-allowlist.ts
+++ b/website/lib/host-allowlist.ts
@@ -1,0 +1,40 @@
+// Host-header allowlist for the proxy middleware. Public-facing traffic must
+// arrive with a Host header that names one of our real domains — anything
+// else (notably the raw .run.app URL used by the price-tracker bot to bypass
+// Cloudflare) gets rejected before any other middleware runs.
+//
+// Domains here are public DNS records — listing them in source is fine.
+// The escape hatch for testing tagged Cloud Run revisions on .run.app is the
+// LETSFG_ALLOW_RUNAPP_DIRECT env var, which is unset in production.
+
+const ALLOWED_DOMAIN_SUFFIXES: ReadonlyArray<string> = ['letsfg.co']
+
+export function isAllowedHost(
+  host: string | null | undefined,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  if (!host) return false
+  const normalised = host.toLowerCase().trim()
+  if (!normalised) return false
+
+  // Strip optional ":port" suffix.
+  const bare = normalised.split(':')[0]
+  if (!bare) return false
+
+  // letsfg.co and any subdomain (www, docs, stats, api, …).
+  for (const suffix of ALLOWED_DOMAIN_SUFFIXES) {
+    if (bare === suffix || bare.endsWith(`.${suffix}`)) return true
+  }
+
+  // Local development — never enabled in production.
+  if (env.NODE_ENV !== 'production') {
+    if (bare === 'localhost' || bare === '127.0.0.1' || bare === '0.0.0.0') return true
+  }
+
+  // Escape hatch for testing tagged Cloud Run revisions on .run.app. Off by
+  // default; switch on per-revision via env var when staging behavior needs
+  // direct access without going through Cloudflare + Firebase Hosting.
+  if (env.LETSFG_ALLOW_RUNAPP_DIRECT === '1' && bare.endsWith('.run.app')) return true
+
+  return false
+}

--- a/website/proxy.ts
+++ b/website/proxy.ts
@@ -12,6 +12,7 @@ import {
 } from './lib/rate-limit'
 import { isBlockedUserAgent } from './lib/ua-blocklist'
 import { extractClientIp, ipMatchesBlockedCidr, pathIsAbuseProtected } from './lib/ip-blocklist'
+import { isAllowedHost } from './lib/host-allowlist'
 import { isPublicShareAssetPath } from './lib/share-preview'
 
 const intlMiddleware = createMiddleware(routing)
@@ -102,6 +103,16 @@ function tooManyRequestsResponse(
 }
 
 export default function proxy(req: NextRequest) {
+  // Host-header allowlist — first gate. Public traffic must arrive via one of
+  // our real domains (letsfg.co + subdomains). Raw .run.app URLs are blocked
+  // here so bots can't bypass Cloudflare by hitting Cloud Run directly.
+  if (!isAllowedHost(resolveRequestHost(req))) {
+    return new NextResponse('Forbidden', {
+      status: 403,
+      headers: { 'Cache-Control': 'no-store' },
+    })
+  }
+
   const { pathname } = req.nextUrl
 
   if (isBlockedUserAgent(req.headers.get('user-agent'))) {

--- a/website/tests/host-allowlist.test.ts
+++ b/website/tests/host-allowlist.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isAllowedHost } from '../lib/host-allowlist'
+
+describe('isAllowedHost', () => {
+  it('allows letsfg.co and known subdomains', () => {
+    assert.equal(isAllowedHost('letsfg.co', {}), true)
+    assert.equal(isAllowedHost('www.letsfg.co', {}), true)
+    assert.equal(isAllowedHost('docs.letsfg.co', {}), true)
+    assert.equal(isAllowedHost('stats.letsfg.co', {}), true)
+    assert.equal(isAllowedHost('api.letsfg.co', {}), true)
+  })
+
+  it('blocks raw Cloud Run .run.app URLs — the bot bypass path', () => {
+    assert.equal(
+      isAllowedHost('letsfg-website-preview-876385716101.us-central1.run.app', {}),
+      false,
+    )
+    assert.equal(
+      isAllowedHost('letsfg-website-preview-qryvus4jia-uc.a.run.app', {}),
+      false,
+    )
+    assert.equal(
+      isAllowedHost('hotfix-ipblock---letsfg-website-preview-qryvus4jia-uc.a.run.app', {}),
+      false,
+    )
+  })
+
+  it('blocks Firebase Hosting default URLs', () => {
+    assert.equal(isAllowedHost('letsfg-preview-sms-caller.web.app', {}), false)
+    assert.equal(isAllowedHost('letsfg-preview-sms-caller.firebaseapp.com', {}), false)
+  })
+
+  it('blocks unrelated hosts', () => {
+    assert.equal(isAllowedHost('example.com', {}), false)
+    assert.equal(isAllowedHost('evil.example.com', {}), false)
+  })
+
+  it('rejects suffix-confusion attacks (no implicit prefix match)', () => {
+    assert.equal(isAllowedHost('notletsfg.co', {}), false)
+    assert.equal(isAllowedHost('letsfg.com', {}), false)
+    assert.equal(isAllowedHost('letsfg.co.evil.com', {}), false)
+    assert.equal(isAllowedHost('xletsfg.co', {}), false)
+  })
+
+  it('strips port suffix before matching', () => {
+    assert.equal(isAllowedHost('letsfg.co:443', {}), true)
+    assert.equal(isAllowedHost('www.letsfg.co:8080', {}), true)
+  })
+
+  it('is case-insensitive', () => {
+    assert.equal(isAllowedHost('LetsFG.co', {}), true)
+    assert.equal(isAllowedHost('WWW.LETSFG.CO', {}), true)
+  })
+
+  it('allows localhost only in non-prod environments', () => {
+    assert.equal(isAllowedHost('localhost', { NODE_ENV: 'development' }), true)
+    assert.equal(isAllowedHost('localhost:3000', { NODE_ENV: 'development' }), true)
+    assert.equal(isAllowedHost('127.0.0.1', { NODE_ENV: 'test' }), true)
+    assert.equal(isAllowedHost('localhost', { NODE_ENV: 'production' }), false)
+    assert.equal(isAllowedHost('127.0.0.1', { NODE_ENV: 'production' }), false)
+  })
+
+  it('honours LETSFG_ALLOW_RUNAPP_DIRECT escape hatch for tagged revisions', () => {
+    const runapp = 'hotfix-ipblock---letsfg-website-preview-qryvus4jia-uc.a.run.app'
+    assert.equal(isAllowedHost(runapp, {}), false)
+    assert.equal(isAllowedHost(runapp, { LETSFG_ALLOW_RUNAPP_DIRECT: '1' }), true)
+    // Even with the escape hatch on, non-runapp hosts still need the regular allowlist.
+    assert.equal(isAllowedHost('evil.com', { LETSFG_ALLOW_RUNAPP_DIRECT: '1' }), false)
+  })
+
+  it('handles null/empty/whitespace safely', () => {
+    assert.equal(isAllowedHost(null, {}), false)
+    assert.equal(isAllowedHost(undefined, {}), false)
+    assert.equal(isAllowedHost('', {}), false)
+    assert.equal(isAllowedHost('   ', {}), false)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `lib/host-allowlist.ts`: rejects any request whose `Host` / `x-forwarded-host` is not `*.letsfg.co` (or localhost in dev)
- Wires it as the **first gate** in `proxy.ts` — fires before UA/IP checks, before intlMiddleware
- Env-var escape hatch `LETSFG_ALLOW_RUNAPP_DIRECT=1` allows `.run.app` access on tagged staging revisions without a code change
- Adds `tests/host-allowlist.test.ts` — 10 assertions covering allowed domains, port stripping, case-insensitivity, suffix-confusion attacks, localhost gating, and the escape hatch

## Why

The `passagens-monitor` bot (and any future variant) bypasses Cloudflare WAF entirely by hitting `letsfg-website-preview-876385716101.us-central1.run.app` directly — CF is never in the data path for those requests, so CF WAF rules and IP reputation lists have zero effect. UA + CIDR blocks in proxy.ts help, but they still process each request. This host-allowlist check fires first and costs almost nothing.

## Test plan

- [x] `npm test` passes (host-allowlist + ip-blocklist + ua-blocklist suites)
- [x] Tagged revision smoke-tested: direct `.run.app` → 403, `x-forwarded-host: letsfg.co` → 307
- [x] Promoted to 100% production traffic (`letsfg-website-preview-00760-hac`)
- [x] `curl https://letsfg.co/` → 307 ✓
- [x] `curl https://letsfg-website-preview-876385716101.us-central1.run.app/` → 403 ✓
- [x] `curl https://letsfg-website-preview-876385716101.us-central1.run.app/results?q=...` → 403 ✓

## Rollback

```
gcloud run services update-traffic letsfg-website-preview \
  --region=us-central1 --project=sms-caller \
  --to-revisions=letsfg-website-preview-00755-xot=100
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)