### PR TITLE
fix(engine): add serpapi_google to fast mode sources

### DIFF
--- a/connectors/engine.py
+++ b/connectors/engine.py
@@ -408,6 +408,8 @@ _FAST_MODE_SOURCES: set[str] = {
     "emirates_direct", "turkish_direct", "finnair_direct",
     # ── Kiwi is always included (global aggregator) ──
     "kiwi_connector",
+    # ── Google Flights — always included (pricing baseline + global coverage) ──
+    "serpapi_google",
 }
 
 # ── Cabin class support ─────────────────────────────────────────────────────

--- a/sdk/python/letsfg/connectors/engine.py
+++ b/sdk/python/letsfg/connectors/engine.py
@@ -412,6 +412,8 @@ _FAST_MODE_SOURCES: set[str] = {
     "emirates_direct", "turkish_direct", "finnair_direct",
     # ── Kiwi is always included (global aggregator) ──
     "kiwi_connector",
+    # ── Google Flights — always included (pricing baseline + global coverage) ──
+    "serpapi_google",
 }
 
 # ── Cabin class support ─────────────────────────────────────────────────────

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "letsfg"
-version = "2026.5.78"
+version = "2026.5.79"
 description = "Flight search & booking for AI agents. 200+ airline connectors run locally, free. Direct booking URLs via letsfg.co concierge or Developer API."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- `serpapi_google` (Google Flights) was missing from `_FAST_MODE_SOURCES`, so it was silently excluded from every fast-mode search — which is the default path in the FSW
- Fixed in both `connectors/engine.py` (flat copy) and `sdk/python/letsfg/connectors/engine.py` (SDK)
- SDK bumped to `2026.5.79` and already published to PyPI
- FSW already updated to `LETSFG_VERSION=2026.5.79` and deployed

## Impact
GF now runs on every search including US domestic routes, providing the pricing baseline for the savings badge and catching deals not in OTA inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)