### PR TITLE
feat(sdk): Twitter/X auth flow + cloud search client

### DIFF
--- a/sdk/python/examples/quickstart.py
+++ b/sdk/python/examples/quickstart.py
@@ -1,39 +1,27 @@
 """
-LetsFG Programmatic Flight Search — 5-minute quickstart.
+LetsFG Programmatic Flight Search — quickstart.
 
-Authentication is free and takes ~30 seconds (Twitter/X, 90-day token).
-Once authenticated, search returns in seconds with no local browsers needed.
+1. Get a free 90-day Bearer token at https://letsfg.co/for-agents
+2. Save it:  letsfg auth --token <your-token>
+             or set LETSFG_BEARER_TOKEN=<your-token>
+3. Run this script.
 
-Run:
-    pip install letsfg
-    python quickstart.py
+Results come back in seconds from 400+ airlines — same schema as before,
+no local browsers required.
 """
 
 from __future__ import annotations
 
 import asyncio
-from letsfg.connectors.auth import twitter_auth, get_bearer_token, BearerTokenError
 from letsfg.local import search_local
 
 
-def authenticate():
-    """Run the Twitter/X auth flow if no valid token exists."""
-    try:
-        get_bearer_token()
-        print("  Already authenticated.")
-    except BearerTokenError:
-        print("  No token found — starting Twitter/X auth flow...")
-        twitter_auth()
-
-
 async def main():
-    authenticate()
-
-    print("\n  Searching WAW → BCN on 2026-07-15...")
+    print("Searching WAW → BCN on 2026-07-15...")
     result = await search_local("WAW", "BCN", "2026-07-15", currency="EUR", limit=5)
 
     offers = result.get("offers", [])
-    print(f"\n  {result.get('total_results', len(offers))} offers found. Top {len(offers)}:\n")
+    print(f"\n{result.get('total_results', len(offers))} offers. Top {len(offers)}:\n")
     for i, offer in enumerate(offers, 1):
         ob = offer.get("outbound", {})
         segs = ob.get("segments", [])
@@ -42,13 +30,12 @@ async def main():
         ) if segs else "?"
         price = offer.get("price", 0)
         currency = offer.get("currency", "EUR")
-        stops = ob.get("stopovers", 0)
         airlines = ", ".join(offer.get("airlines", [offer.get("owner_airline", "?")]))
-        print(f"  {i}. {currency} {price:.2f}  {airlines:<20}  {route}  ({stops} stop{'s' if stops != 1 else ''})")
+        print(f"  {i}. {currency} {price:.2f}  {airlines:<20}  {route}")
 
     if offers:
-        print(f"\n  To reveal the booking link for offer #{1}:")
-        print(f"    letsfg unlock {offers[0].get('id', '<offer_id>')}\n")
+        print(f"\nTo reveal the booking link:")
+        print(f"  letsfg unlock {offers[0].get('id', '<offer_id>')}\n")
 
 
 if __name__ == "__main__":

--- a/sdk/python/examples/quickstart.py
+++ b/sdk/python/examples/quickstart.py
@@ -1,23 +1,34 @@
 """
 LetsFG Programmatic Flight Search — quickstart.
 
-1. Get a free 90-day Bearer token at https://letsfg.co/for-agents
-2. Save it:  letsfg auth --token <your-token>
-             or set LETSFG_BEARER_TOKEN=<your-token>
-3. Run this script.
+Auth is free (Twitter/X challenge, ~30s) and lasts 90 days.
+Once authenticated, searches return in seconds from 400+ airlines.
 
-Results come back in seconds from 400+ airlines — same schema as before,
-no local browsers required.
+Run:
+    pip install letsfg
+    python quickstart.py
 """
 
 from __future__ import annotations
 
 import asyncio
+from letsfg.connectors.auth import twitter_auth, get_bearer_token, BearerTokenError
 from letsfg.local import search_local
 
 
-async def main():
-    print("Searching WAW → BCN on 2026-07-15...")
+def ensure_auth() -> None:
+    """Authenticate if no valid token exists."""
+    try:
+        get_bearer_token()
+    except BearerTokenError:
+        print("No token found — starting Twitter/X auth...")
+        twitter_auth()
+
+
+async def main() -> None:
+    ensure_auth()
+
+    print("\nSearching WAW → BCN on 2026-07-15...")
     result = await search_local("WAW", "BCN", "2026-07-15", currency="EUR", limit=5)
 
     offers = result.get("offers", [])
@@ -34,7 +45,7 @@ async def main():
         print(f"  {i}. {currency} {price:.2f}  {airlines:<20}  {route}")
 
     if offers:
-        print(f"\nTo reveal the booking link:")
+        print(f"\nUnlock offer #{1} (reveals direct booking link):")
         print(f"  letsfg unlock {offers[0].get('id', '<offer_id>')}\n")
 
 

--- a/sdk/python/letsfg/cli.py
+++ b/sdk/python/letsfg/cli.py
@@ -486,26 +486,33 @@ def search(
     print()
 
 
-# ── Star (Link GitHub) ─────────────────────────────────────────────────────
-
 @app.command()
-def auth():
-    """Authenticate with LetsFG via Twitter/X — free, 90-day token.
+def auth(
+    token: Optional[str] = typer.Option(None, "--token", "-t", help="Your LetsFG Bearer token"),
+):
+    """Save your LetsFG Bearer token for free programmatic flight search.
 
-    1. Run this command.
-    2. Post the displayed tweet from your Twitter/X account.
-    3. Press Enter. Done — token is saved locally.
+    Get a free 90-day token (Twitter/X auth) at:
+        https://letsfg.co/for-agents
 
-    You only need to do this once every 90 days.
+    Then run:
+        letsfg auth --token <your-token>
     """
-    from letsfg.connectors.auth import twitter_auth, BearerTokenError
-    try:
-        twitter_auth()
-        print("\n  You're all set. Run: letsfg search WAW BCN 2026-07-15\n")
-    except BearerTokenError as e:
-        _err(str(e))
-    except Exception as e:
-        _err(f"Auth failed: {e}")
+    from letsfg.connectors.auth import save_token, get_bearer_token, BearerTokenError
+
+    if not token:
+        print("\n  Get your free Bearer token (90-day, Twitter/X auth) at:")
+        print("    https://letsfg.co/for-agents\n")
+        print("  Then run:  letsfg auth --token <your-token>\n")
+        try:
+            get_bearer_token()
+            print("  (You already have a valid token saved.)\n")
+        except BearerTokenError:
+            pass
+        return
+
+    save_token(token)
+    print("\n  Token saved. Run: letsfg search WAW BCN 2026-07-15\n")
 
 
 # ── Unlock ────────────────────────────────────────────────────────────────

--- a/sdk/python/letsfg/cli.py
+++ b/sdk/python/letsfg/cli.py
@@ -487,32 +487,20 @@ def search(
 
 
 @app.command()
-def auth(
-    token: Optional[str] = typer.Option(None, "--token", "-t", help="Your LetsFG Bearer token"),
-):
-    """Save your LetsFG Bearer token for free programmatic flight search.
+def auth():
+    """Authenticate via Twitter/X — free, one-time, 90-day token.
 
-    Get a free 90-day token (Twitter/X auth) at:
-        https://letsfg.co/for-agents
-
-    Then run:
-        letsfg auth --token <your-token>
+    Posts a one-time challenge to verify your Twitter/X account.
+    Token is saved locally and reused automatically for 90 days.
     """
-    from letsfg.connectors.auth import save_token, get_bearer_token, BearerTokenError
-
-    if not token:
-        print("\n  Get your free Bearer token (90-day, Twitter/X auth) at:")
-        print("    https://letsfg.co/for-agents\n")
-        print("  Then run:  letsfg auth --token <your-token>\n")
-        try:
-            get_bearer_token()
-            print("  (You already have a valid token saved.)\n")
-        except BearerTokenError:
-            pass
-        return
-
-    save_token(token)
-    print("\n  Token saved. Run: letsfg search WAW BCN 2026-07-15\n")
+    from letsfg.connectors.auth import twitter_auth, BearerTokenError
+    try:
+        twitter_auth()
+        print("\n  You're all set. Run: letsfg search WAW BCN 2026-07-15\n")
+    except BearerTokenError as e:
+        _err(str(e))
+    except Exception as e:
+        _err(f"Auth failed: {e}")
 
 
 # ── Unlock ────────────────────────────────────────────────────────────────

--- a/sdk/python/letsfg/connectors/__init__.py
+++ b/sdk/python/letsfg/connectors/__init__.py
@@ -1,18 +1,11 @@
 """
 LetsFG flight connectors — run server-side at letsfg.co.
 
-Authenticate once via Twitter/X to get a free 90-day Bearer token,
-then run unlimited searches via the cloud API.
-
-Quick start:
-    letsfg auth        # one-time Twitter/X auth (~30 seconds)
+Get a free 90-day Bearer token at https://letsfg.co/for-agents, then:
+    letsfg auth --token <token>
     letsfg search WAW BCN 2026-07-15
-
-Or programmatically:
-    from letsfg.connectors.auth import twitter_auth, get_bearer_token
-    twitter_auth()     # interactive: prints a tweet to post, waits for confirmation
 """
 
-from .auth import twitter_auth, get_bearer_token, BearerTokenError
+from .auth import get_bearer_token, save_token, BearerTokenError
 
-__all__ = ["twitter_auth", "get_bearer_token", "BearerTokenError"]
+__all__ = ["get_bearer_token", "save_token", "BearerTokenError"]

--- a/sdk/python/letsfg/connectors/__init__.py
+++ b/sdk/python/letsfg/connectors/__init__.py
@@ -1,11 +1,11 @@
 """
 LetsFG flight connectors — run server-side at letsfg.co.
 
-Get a free 90-day Bearer token at https://letsfg.co/for-agents, then:
-    letsfg auth --token <token>
+Authenticate once via Twitter/X (free, 90-day token), then search instantly:
+    letsfg auth
     letsfg search WAW BCN 2026-07-15
 """
 
-from .auth import get_bearer_token, save_token, BearerTokenError
+from .auth import twitter_auth, get_bearer_token, save_token, BearerTokenError
 
-__all__ = ["get_bearer_token", "save_token", "BearerTokenError"]
+__all__ = ["twitter_auth", "get_bearer_token", "save_token", "BearerTokenError"]

--- a/sdk/python/letsfg/connectors/auth.py
+++ b/sdk/python/letsfg/connectors/auth.py
@@ -1,14 +1,15 @@
 """
-Twitter/X authentication for LetsFG Programmatic Flight Search (PFS).
+LetsFG Programmatic Flight Search (PFS) — token management.
 
-Flow:
-  1. POST /api/agent-access/request  — server returns a one-time challenge token
-  2. Tweet "@letsfg <challenge>"     — proves account ownership
-  3. POST /api/agent-access/verify   — server confirms tweet, returns 90-day Bearer
-  4. Token stored in ~/.letsfg/config.json
+Get your free 90-day Bearer token at:
+    https://letsfg.co/for-agents
 
-The Bearer token is passed as "Authorization: Bearer <token>" on every
-POST /api/search and GET /api/results/<id> call.
+Once you have it:
+    letsfg auth --token <your-token>
+    # or
+    export LETSFG_BEARER_TOKEN=<your-token>
+
+The token is passed as "Authorization: Bearer <token>" on every API call.
 """
 
 from __future__ import annotations
@@ -17,15 +18,10 @@ import json
 import os
 import time
 from pathlib import Path
-from urllib.request import Request, urlopen
-from urllib.error import HTTPError
-
-_BASE_URL = os.environ.get("LETSFG_BASE_URL", "https://letsfg.co")
-_TOKEN_TTL = 90 * 24 * 3600  # 90 days in seconds
 
 
 class BearerTokenError(Exception):
-    """No valid Bearer token. Run `letsfg auth` to authenticate via Twitter/X."""
+    """No valid Bearer token. Get one at https://letsfg.co/for-agents"""
     pass
 
 
@@ -69,67 +65,16 @@ def get_bearer_token() -> str:
 
     raise BearerTokenError(
         "No valid LetsFG Bearer token.\n"
-        "  Run:  letsfg auth\n"
-        "  Or:   export LETSFG_BEARER_TOKEN=<token>"
+        "  Get one: https://letsfg.co/for-agents\n"
+        "  Then:    letsfg auth --token <token>\n"
+        "  Or:      export LETSFG_BEARER_TOKEN=<token>"
     )
 
 
-def _save_token(token: str, expires_at: float) -> None:
+def save_token(token: str, expires_at: float | None = None) -> None:
+    """Save a Bearer token to the local config."""
+    if expires_at is None:
+        expires_at = time.time() + 90 * 24 * 3600
     cfg = _load_config()
     cfg["pfs_auth"] = {"token": token, "expires_at": expires_at}
     _save_config(cfg)
-
-
-def _post_json(path: str, payload: dict, timeout: int = 30) -> dict:
-    body = json.dumps(payload).encode()
-    req = Request(
-        f"{_BASE_URL}{path}",
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read())
-
-
-def twitter_auth() -> str:
-    """
-    Interactive Twitter/X auth flow. Prints the tweet to post, waits for
-    the user to confirm, verifies with the server, saves and returns the token.
-    """
-    print("\n  Connecting to LetsFG...")
-    data = _post_json("/api/agent-access/request", {})
-    challenge = data["challenge"]
-    tweet_text = data.get("tweet_text") or f"@letsfg {challenge}"
-
-    print(f"\n  Step 1 — post this exact tweet:\n")
-    print(f"     {tweet_text}\n")
-    print(f"  Step 2 — press Enter once it's live.")
-    input()
-
-    print("  Verifying... ", end="", flush=True)
-    try:
-        result = _post_json("/api/agent-access/verify", {"challenge": challenge})
-    except HTTPError as e:
-        body = e.read().decode(errors="replace")
-        raise BearerTokenError(
-            f"Verification failed (HTTP {e.code}). "
-            "Make sure you posted the exact tweet above.\n"
-            f"Server: {body[:200]}"
-        )
-
-    token = result["token"]
-    raw_exp = result.get("expires_at")
-    if isinstance(raw_exp, (int, float)):
-        expires_at = float(raw_exp)
-    elif isinstance(raw_exp, str):
-        from datetime import datetime, timezone
-        expires_at = datetime.fromisoformat(raw_exp.replace("Z", "+00:00")).timestamp()
-    else:
-        expires_at = time.time() + _TOKEN_TTL
-
-    _save_token(token, expires_at)
-    from datetime import datetime
-    exp_str = datetime.fromtimestamp(expires_at).strftime("%Y-%m-%d")
-    print(f"done. Token valid until {exp_str}.")
-    return token

--- a/sdk/python/letsfg/connectors/auth.py
+++ b/sdk/python/letsfg/connectors/auth.py
@@ -1,15 +1,19 @@
 """
-LetsFG Programmatic Flight Search (PFS) — token management.
+Twitter/X authentication for LetsFG Programmatic Flight Search (PFS).
 
-Get your free 90-day Bearer token at:
-    https://letsfg.co/for-agents
+Flow (one-time, ~30 seconds):
+  1. POST https://letsfg.co/api/agent-access/request
+     → { challenge_code, tweet_text, expires_at }
+  2. Post the tweet_text from your Twitter/X account.
+  3. POST https://letsfg.co/api/agent-access/verify  { challenge_code }
+     → { token, expires_at }   (90-day Bearer token)
 
-Once you have it:
-    letsfg auth --token <your-token>
-    # or
-    export LETSFG_BEARER_TOKEN=<your-token>
+After that, every search call uses:
+    Authorization: Bearer <token>
+    POST https://letsfg.co/api/search
+    GET  https://letsfg.co/api/results/<search_id>
 
-The token is passed as "Authorization: Bearer <token>" on every API call.
+Run `letsfg auth` to do all of this interactively.
 """
 
 from __future__ import annotations
@@ -18,10 +22,15 @@ import json
 import os
 import time
 from pathlib import Path
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+
+_BASE_URL = os.environ.get("LETSFG_BASE_URL", "https://letsfg.co")
+_TOKEN_TTL = 90 * 24 * 3600  # 90 days
 
 
 class BearerTokenError(Exception):
-    """No valid Bearer token. Get one at https://letsfg.co/for-agents"""
+    """No valid Bearer token. Run `letsfg auth` to authenticate via Twitter/X."""
     pass
 
 
@@ -65,16 +74,75 @@ def get_bearer_token() -> str:
 
     raise BearerTokenError(
         "No valid LetsFG Bearer token.\n"
-        "  Get one: https://letsfg.co/for-agents\n"
-        "  Then:    letsfg auth --token <token>\n"
-        "  Or:      export LETSFG_BEARER_TOKEN=<token>"
+        "  Run:  letsfg auth\n"
+        "  Or:   export LETSFG_BEARER_TOKEN=<token>"
     )
 
 
 def save_token(token: str, expires_at: float | None = None) -> None:
-    """Save a Bearer token to the local config."""
+    """Save a Bearer token to ~/.letsfg/config.json."""
     if expires_at is None:
-        expires_at = time.time() + 90 * 24 * 3600
+        expires_at = time.time() + _TOKEN_TTL
     cfg = _load_config()
     cfg["pfs_auth"] = {"token": token, "expires_at": expires_at}
     _save_config(cfg)
+
+
+def _post_json(path: str, payload: dict, timeout: int = 30) -> dict:
+    body = json.dumps(payload).encode()
+    req = Request(
+        f"{_BASE_URL}{path}",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def twitter_auth() -> str:
+    """
+    Interactive auth flow — call this once to get a 90-day Bearer token.
+
+    Steps:
+      1. Calls POST /api/agent-access/request to get a challenge.
+      2. Prints the exact tweet to post.
+      3. Waits for you to post it, then calls POST /api/agent-access/verify.
+      4. Saves the token to ~/.letsfg/config.json and returns it.
+    """
+    print("\n  Connecting to LetsFG...")
+    data = _post_json("/api/agent-access/request", {})
+    challenge_code = data["challenge_code"]
+    tweet_text = data.get("tweet_text") or f"@letsfg {challenge_code}"
+
+    print(f"\n  Step 1 — post this tweet from your Twitter/X account:\n")
+    print(f"     {tweet_text}\n")
+    print(f"  Step 2 — press Enter once it's live.")
+    input()
+
+    print("  Verifying... ", end="", flush=True)
+    try:
+        result = _post_json("/api/agent-access/verify", {"challenge_code": challenge_code})
+    except HTTPError as e:
+        body = e.read().decode(errors="replace")
+        raise BearerTokenError(
+            f"Verification failed (HTTP {e.code}). "
+            "Make sure you posted the exact tweet above.\n"
+            f"Server: {body[:200]}"
+        )
+
+    token = result["token"]
+    raw_exp = result.get("expires_at")
+    if isinstance(raw_exp, (int, float)):
+        expires_at = float(raw_exp)
+    elif isinstance(raw_exp, str):
+        from datetime import datetime, timezone
+        expires_at = datetime.fromisoformat(raw_exp.replace("Z", "+00:00")).timestamp()
+    else:
+        expires_at = time.time() + _TOKEN_TTL
+
+    save_token(token, expires_at)
+    from datetime import datetime
+    exp_str = datetime.fromtimestamp(expires_at).strftime("%Y-%m-%d")
+    print(f"done. Token valid until {exp_str}.")
+    return token


### PR DESCRIPTION
## What

Finalizes the connector removal. The public SDK now authenticates via Twitter/X and routes all searches through the LetsFG cloud API.

## Auth flow (documented in `auth.py`)

```
POST https://letsfg.co/api/agent-access/request
→ { challenge_code, tweet_text, expires_at }

# Post tweet_text from your Twitter/X account

POST https://letsfg.co/api/agent-access/verify  { challenge_code }
→ { token, expires_at }   # 90-day Bearer token
```

Then every search call uses `Authorization: Bearer <token>`.

## Search flow (in `local.py`)

```
POST https://letsfg.co/api/search  + Bearer token
→ { search_id }

GET https://letsfg.co/api/results/<search_id>  + Bearer token  (poll every 10s)
→ { status, offers[], total_results }
```

## CLI

```
letsfg auth                          # one-time Twitter/X auth, token saved locally
letsfg search WAW BCN 2026-07-15    # searches via cloud API
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)