### PR TITLE
docs: replace broken star-history.com chart with self-hosted endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,11 +470,11 @@ Direct airline booking_url — no checkout, no concierge fee
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=LetsFG%2FLetsFG&type=date&legend=top-left">
+<a href="https://github.com/LetsFG/LetsFG">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=LetsFG/LetsFG&type=date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=LetsFG/LetsFG&type=date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/image?repos=LetsFG/LetsFG&type=date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://letsfg.co/api/stars/history?theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://letsfg.co/api/stars/history?theme=light" />
+    <img alt="Star History Chart" src="https://letsfg.co/api/stars/history?theme=light" />
   </picture>
 </a>
 


### PR DESCRIPTION
## Summary
- GitHub restricted the stargazers timestamp feed to repo admins/collaborators (June 2026) — `api.star-history.com/image` now 404s for every third-party repo, which is why the Star History chart at the bottom of the README went blank.
- Points the chart at `https://letsfg.co/api/stars/history` (light/dark), a self-hosted SVG chart backed by the same `GITHUB_TOKEN` already used for the stars-count badge — no third-party token embed needed.

## Depends on
- LetsFG/LetsFG-private#69 (backend endpoint) — needs to be merged and deployed first, otherwise this image 404s.

## Test plan
- [x] Backend endpoint tested against real GitHub API (1,531 stars, 116-day series, valid SVG both themes) — see LetsFG-private#69
- [ ] After the backend PR deploys, load this README on GitHub and confirm the chart renders in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)