### PR TITLE
docs: expand hero with whole-trip vision, self-host follow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Or having that feeling you could've got a better deal if you'd just waited a lit
 **So we built something about it.**<br>
 No markup. No tracking. No price that goes up because you looked twice.
 
+**We started with flights. We're not stopping there.**<br>
+The plan: one agent for the whole trip. It finds the real best deal across every airline and OTA, picks the right airport when your city has three, sorts ground transport on the other end, and watches your flight so a delay or cancellation gets handled before you're the one stuck in a rebooking line.<br>
+Search and booking work today. The rest is what we're building next.
+
 <br>
 
 [<img src="https://img.shields.io/badge/⭐_Star_to_show_love-FFD700?style=for-the-badge&logoColor=black" alt="Star to show love">](https://github.com/LetsFG/LetsFG)
@@ -24,11 +28,11 @@ No markup. No tracking. No price that goes up because you looked twice.
 
 <br>
 
-[<img src="https://img.shields.io/badge/Follow_on_Instagram-E4405F?style=for-the-badge&logo=instagram&logoColor=white" alt="Follow on Instagram">](https://www.instagram.com/letsfg_)
+[<img src="assets/badge-instagram.svg" alt="Follow on Instagram">](https://www.instagram.com/letsfg_)
 &nbsp;&nbsp;
-[<img src="https://img.shields.io/badge/Follow_on_TikTok-000000?style=for-the-badge&logo=tiktok&logoColor=white" alt="Follow on TikTok">](https://www.tiktok.com/@letsfg_)
+[<img src="assets/badge-tiktok.svg" alt="Follow on TikTok">](https://www.tiktok.com/@letsfg_)
 &nbsp;&nbsp;
-[<img src="https://img.shields.io/badge/Follow_on_X-111111?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X">](https://x.com/LetsFG_)
+[<img src="assets/badge-x.svg" alt="Follow on X">](https://x.com/LetsFG_)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 
 # We're LetsFG — a community of travelers.
 
-Finding a flight shouldn't mean checking 47 websites. Or 3 hours of searching.<br>
-Or having that feeling you could've got a better deal if you'd just waited a little longer.
+Planning a trip shouldn't mean 47 tabs open, 3 hours of searching, and that feeling you could've got a better deal if you'd just waited a little longer.<br>
+Then a separate app to watch for delays. Then another one for the ride to the airport.
 
-**So we built something about it.**<br>
+**So we're building one thing that handles all of it.**<br>
+The real best deal, across every airline and OTA. The right airport when your city has three. Ground transport on the other end. Someone watching your flight so a delay or cancellation gets handled before you're the one stuck in a line.
+
 No markup. No tracking. No price that goes up because you looked twice.
 
-**We started with flights. We're not stopping there.**<br>
-The plan: one agent for the whole trip. It finds the real best deal across every airline and OTA, picks the right airport when your city has three, sorts ground transport on the other end, and watches your flight so a delay or cancellation gets handled before you're the one stuck in a rebooking line.<br>
-Search and booking work today. The rest is what we're building next.
+Search and booking work today, right here in this repo. The rest is what we're building next.
 
 <br>
 
@@ -52,7 +52,7 @@ Search and booking work today. The rest is what we're building next.
 
 ---
 
-# Your AI agent just learned to book flights.
+# Flights are step one. Here's the part that's live.
 
 **Hundreds of airlines. Real prices. One function call.**
 

--- a/assets/badge-instagram.svg
+++ b/assets/badge-instagram.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="224" height="28" viewBox="0 0 224 28" role="img" aria-label="Follow on Instagram">
+  <rect width="224" height="28" fill="#E4405F"/>
+  <text x="20" y="14" dominant-baseline="central" font-family="Verdana, Geneva, DejaVu Sans, sans-serif" font-size="13" font-weight="bold" letter-spacing="0.5" fill="#ffffff">&#128247; FOLLOW ON INSTAGRAM</text>
+</svg>

--- a/assets/badge-tiktok.svg
+++ b/assets/badge-tiktok.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="190" height="28" viewBox="0 0 190 28" role="img" aria-label="Follow on TikTok">
+  <rect width="190" height="28" fill="#000000"/>
+  <text x="20" y="14" dominant-baseline="central" font-family="Verdana, Geneva, DejaVu Sans, sans-serif" font-size="13" font-weight="bold" letter-spacing="0.5" fill="#ffffff">&#127925; FOLLOW ON TIKTOK</text>
+</svg>

--- a/assets/badge-x.svg
+++ b/assets/badge-x.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="28" viewBox="0 0 150 28" role="img" aria-label="Follow on X">
+  <rect width="150" height="28" fill="#111111"/>
+  <text x="20" y="14" dominant-baseline="central" font-family="Verdana, Geneva, DejaVu Sans, sans-serif" font-size="13" font-weight="bold" letter-spacing="0.5" fill="#ffffff">&#120143; FOLLOW ON X</text>
+</svg>


### PR DESCRIPTION
## Summary
- Adds a short paragraph to the README hero making explicit that LetsFG is expanding beyond flight search toward the whole trip (best airport, ground transport, disruption/delay handling) — framed as roadmap, not shipped capability, since none of that is live in this repo or on letsfg.co yet.
- Fixes broken Follow-on-TikTok / Follow-on-X badges by self-hosting them as static SVGs in `assets/`. Root cause: shields.io is currently returning 524s; Instagram's badge only survived because GitHub's camo cache had a pre-outage copy. Same fix pattern already used for the star-history chart and connector-health badge.

## Test plan
- [x] Verified TikTok/X badges were actually broken (`naturalWidth: 0`) via a live render check on the current README
- [x] Verified all three shields.io badge URLs return 524 directly
- [x] Validated the new SVGs are well-formed XML
- [ ] Visual check once merged that the new badges render as expected on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)