### PR TITLE
fix(mcp): poll until search completes (handle "searching" status → fixes total_offers:0)

### DIFF
--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -60,7 +60,7 @@ async function searchPFS(params: Record<string, unknown>): Promise<Record<string
     });
     if (pollResp.ok) {
       const result = await pollResp.json() as Record<string, unknown>;
-      if (result.status !== 'pending') return result;
+      if (!['pending', 'searching'].includes(result.status as string)) return result;  // API reports in-progress as 'searching'; only 'completed' (etc.) is terminal
     }
   }
   return { error: true, detail: 'Search timed out after 120s.' };


### PR DESCRIPTION
### Problem
`search_flights` returns `total_offers: 0` even for routes with plenty of flights.

### Cause
The async poll loop in `sdk/mcp/src/index.ts` returns on the first result where `status !== 'pending'`. But `/api/results/<id>` reports in-progress as `"searching"` and done as `"completed"` — never `"pending"` — so it returns on the first poll (~10s, search ~15% done) with an empty `offers[]`.

### Effect
Every search returns `total_offers: 0` after ~10s. Polling the same `search_id` to completion returns 30+ real offers — confirming it's the poll condition, not the API/auth.

### Fix
Poll through `pending`/`searching`; return only on a terminal status:
```ts
if (!['pending', 'searching'].includes(result.status as string)) return result;
```
Verified live (SFO→CAI): before `total_offers: 0` → after `total_offers: 34`.