### PR TITLE
fix(): Add departure_time_from/departure_time_to to JS SDK, MCP server and CLI

### DIFF
--- a/sdk/js/src/cli.ts
+++ b/sdk/js/src/cli.ts
@@ -73,6 +73,8 @@ async function cmdSearch(args: string[]) {
   const currency = getFlag(args, '--currency') || 'EUR';
   const limit = parseInt(getFlag(args, '--limit', '-l') || '20');
   const sort = (getFlag(args, '--sort') || 'price') as 'price' | 'duration';
+  const departureFrom = getFlag(args, '--departure-from');
+  const departureTo = getFlag(args, '--departure-to');
 
   const [origin, destination, date] = args;
   if (!origin || !destination || !date) {
@@ -89,6 +91,8 @@ async function cmdSearch(args: string[]) {
     currency,
     limit,
     sort,
+    departureTimeFrom: departureFrom,
+    departureTimeTo: departureTo,
   });
 
   if (jsonOut) {

--- a/sdk/js/src/index.test.ts
+++ b/sdk/js/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   cheapestOffer,
   type FlightOffer,
   type FlightSearchResult,
+  type SearchOptions,
 } from './index.js';
 
 // ── Class instantiation ───────────────────────────────────────────────────
@@ -142,6 +143,31 @@ describe('ErrorCode', () => {
 });
 
 // ── Utility functions ─────────────────────────────────────────────────────
+
+describe('SearchOptions', () => {
+  it('accepts departureTimeFrom and departureTimeTo', () => {
+    const opts: SearchOptions = {
+      departureTimeFrom: '06:00',
+      departureTimeTo: '14:00',
+    };
+    assert.equal(opts.departureTimeFrom, '06:00');
+    assert.equal(opts.departureTimeTo, '14:00');
+  });
+
+  it('works alongside other options', () => {
+    const opts: SearchOptions = {
+      adults: 2,
+      cabinClass: 'C',
+      departureTimeFrom: '08:00',
+      departureTimeTo: '20:00',
+      sort: 'price',
+    };
+    assert.equal(opts.adults, 2);
+    assert.equal(opts.cabinClass, 'C');
+    assert.equal(opts.departureTimeFrom, '08:00');
+    assert.equal(opts.departureTimeTo, '20:00');
+  });
+});
 
 function makeOffer(price: number, id = 'offer_1'): FlightOffer {
   return {

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -123,6 +123,8 @@ export interface SearchOptions {
   currency?: string;
   limit?: number;
   sort?: 'price' | 'duration';
+  departureTimeFrom?: string;
+  departureTimeTo?: string;
 }
 
 export interface LetsFGConfig {
@@ -364,6 +366,8 @@ export class LetsFG {
     if (options.cabinClass) body.cabin_class = options.cabinClass;
     if (options.maxStopovers != null) body.max_stopovers = options.maxStopovers;
     if (options.sort) body.sort = options.sort;
+    if (options.departureTimeFrom) body.departure_time_from = options.departureTimeFrom;
+    if (options.departureTimeTo) body.departure_time_to = options.departureTimeTo;
 
     if (this.usingPFS) {
       return this.searchPFS(body);

--- a/sdk/mcp/src/index.test.ts
+++ b/sdk/mcp/src/index.test.ts
@@ -122,6 +122,25 @@ describe('MCP server — tools/list', () => {
       assert.ok(tool.inputSchema !== null && typeof tool.inputSchema === 'object', `tool.inputSchema missing on: ${tool.name}`);
     }
   });
+  it('search_flights schema includes departure_time filters', async () => {
+    sendMessage(proc, { jsonrpc: '2.0', id: 1, method: 'initialize', params: {
+      protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '1' },
+    }});
+    await readNextMessage(proc);
+
+    sendMessage(proc, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+    const response = await readNextMessage(proc);
+
+    const result = response.result as Record<string, unknown>;
+    const tools = result.tools as Array<Record<string, unknown>>;
+    const searchTool = tools.find(t => t.name === 'search_flights');
+    assert.ok(searchTool, 'search_flights tool should exist');
+
+    const inputSchema = searchTool.inputSchema as Record<string, unknown>;
+    const props = inputSchema.properties as Record<string, unknown>;
+    assert.ok(props.departure_time_from, 'departure_time_from should exist in schema');
+    assert.ok(props.departure_time_to, 'departure_time_to should exist in schema');
+  });
 });
 
 describe('MCP server — resources/list', () => {

--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -175,6 +175,8 @@ const TOOLS = [
         cabin_class: { type: 'string', description: 'M=economy, W=premium, C=business, F=first', enum: ['M', 'W', 'C', 'F'] },
         currency: { type: 'string', description: 'Currency code (EUR, USD, GBP)', default: 'EUR' },
         max_results: { type: 'integer', description: 'Max offers to return', default: 10 },
+        departure_time_from: { type: 'string', description: "Earliest departure time HH:MM (e.g., '06:00')" },
+        departure_time_to: { type: 'string', description: "Latest departure time HH:MM (e.g., '14:00')" },
       },
     },
   },
@@ -292,6 +294,8 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<st
       };
       if (args.return_from) params.return_from = args.return_from;
       if (args.cabin_class) params.cabin_class = args.cabin_class;
+      if (args.departure_time_from) params.departure_time_from = args.departure_time_from;
+      if (args.departure_time_to) params.departure_time_to = args.departure_time_to;
 
       let result: Record<string, unknown>;
       if (BEARER_TOKEN) {


### PR DESCRIPTION
# PR: Add `departure_time_from` / `departure_time_to` to JS SDK, MCP Server, and CLI

## Issue

The Python SDK already supports filtering flights by a departure time window using `departure_time_from` and `departure_time_to`. However, the JavaScript SDK, MCP server, and CLI were never updated when those parameters were introduced.

As a result, JavaScript users had no way to filter flights by departure time.

## Before

### JS SDK

`departureTimeFrom` and `departureTimeTo` were silently ignored.

```ts
const bt = new LetsFG({ apiKey: 'trav_test' });

await bt.search('LHR', 'JFK', '2026-09-01', {
  departureTimeFrom: '06:00',
});
```

Result:

- API request body did **not** include `departure_time_from`
- Users received **all** flights regardless of departure time

### CLI

The flags did not exist.

```bash
letsfg search LHR JFK 2026-09-01 --departure-from 06:00
```

Result:

- Unknown flag
- Departure time filter was ignored

### MCP Server

The `search_flights` tool schema and handler did not expose or forward:

- `departure_time_from`
- `departure_time_to`

---

## After

### JS SDK

`departureTimeFrom` and `departureTimeTo` are now forwarded to the API.

```ts
await bt.search('LHR', 'JFK', '2026-09-01', {
  departureTimeFrom: '06:00',
  departureTimeTo: '14:00',
});
```

Result:

- API request body now includes:

```json
{
  "departure_time_from": "06:00",
  "departure_time_to": "14:00"
}
```

- Only flights departing between **06:00** and **14:00** are returned.

### CLI

The CLI now supports departure time filtering.

```bash
letsfg search LHR JFK 2026-09-01 \
  --departure-from 06:00 \
  --departure-to 14:00
```

### MCP Server

The `search_flights` tool now accepts:

- `departure_time_from`
- `departure_time_to`

and forwards both parameters to the API.

---

## Files Changed

| File | Changes |
|------|---------|
| `sdk/js/src/index.ts` | Added `departureTimeFrom?` and `departureTimeTo?` to `SearchOptions` and mapped them to `departure_time_from` / `departure_time_to` in API requests. |
| `sdk/js/src/cli.ts` | Added `--departure-from` and `--departure-to` CLI flags in `cmdSearch` and forwarded them to `bt.search()`. |
| `sdk/mcp/src/index.ts` | Added `departure_time_from` and `departure_time_to` to the `search_flights` tool `inputSchema` and forwarded them in the handler. |
| `sdk/js/src/index.test.ts` | Added two unit tests covering the new `SearchOptions` fields (type correctness and combined options). |
| `sdk/mcp/src/index.test.ts` | Added one schema test verifying `departure_time_from` and `departure_time_to` are exposed by the `search_flights` tool. |

---

## Tests

- ✅ JS SDK: **22/22** passing (**+2** new tests)
- ✅ MCP Server: **6/6** passing (**+1** new test)