### PR TITLE
Stop steering agents into the paid Developer API; document payment-token auth

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
     "env": {
       "LETSFG_API_KEY": "${LETSFG_API_KEY}"
     },
-    "description": "Flight search & booking for AI agents. Server-side engine covers hundreds of airlines. Zero price bias, raw airline prices. Free search with letsfg auth (Twitter/X Bearer token) or prepaid Developer API.",
+    "description": "Flight search & booking for AI agents. Server-side engine covers hundreds of airlines. Zero price bias, raw airline prices. Free search with letsfg auth (payment-token Bearer auth, nothing charged) or prepaid Developer API.",
     "homepage": "https://letsfg.co",
     "repository": "https://github.com/LetsFG/LetsFG"
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,22 @@
 
 > This file is for AI agents. If you're a human, see [README.md](README.md).
 
+## ⚠️ Read this first
+
+**Do NOT call `/developers/api/v1/agents/register`.**
+**Do NOT call `/developers/api/v1/agents/setup-payment`.**
+**Do NOT run `letsfg register` or `letsfg setup-payment`.**
+
+Those belong to a **separate, paid, prepaid-balance product** for high-volume
+commercial integrations, and they create a billing account you almost certainly
+do not want. Earlier versions of this file pointed there by default; that was
+wrong, and agents were creating accounts nobody needed.
+
+If you are an agent searching or booking flights — even hundreds of them — you
+want **Programmatic Flight Search (PFS)**: run `letsfg auth`, then search and
+book. One step, no billing account, nothing charged. Full guide:
+<https://letsfg.co/for-agents>.
+
 ## What is LetsFG?
 
 LetsFG is the largest agent-native flight search and booking toolkit. It gives your agent access to a server-side search engine covering hundreds of airlines — production-grade, maintained by LetsFG, not scrapers you have to keep alive. Built for OpenClaw, Perplexity Computer, Claude, Cursor, Windsurf, and any MCP-compatible agent.
@@ -10,7 +26,7 @@ LetsFG is the largest agent-native flight search and booking toolkit. It gives y
 
 ### How it works:
 
-**Server-side search engine** — Ryanair, EasyJet, Wizz Air, Southwest, AirAsia, Norwegian, Qantas, LATAM, Spirit, Frontier, IndiGo, VietJet, and hundreds more. The connectors run server-side at letsfg.co. Authenticate once with a free Twitter/X Bearer token (or a Developer API key), then search is free and unlimited.
+**Server-side search engine** — Ryanair, EasyJet, Wizz Air, Southwest, AirAsia, Norwegian, Qantas, LATAM, Spirit, Frontier, IndiGo, VietJet, and hundreds more. The connectors run server-side at letsfg.co. Authenticate once with `letsfg auth` (a zero-amount card setup — nothing is charged), then search is free and unlimited.
 
 ### What makes this different from flight websites:
 
@@ -26,11 +42,11 @@ LetsFG is the largest agent-native flight search and booking toolkit. It gives y
 
 | Mode | Best for | Speed | Cost |
 |------|----------|-------|------|
-| **CLI / SDK / MCP** (PFS Bearer token) | Personal use, experimentation, any agent | 60–90 s | Free search; unlock 1% (min $3) |
+| **CLI / SDK / MCP** (PFS payment token) | **Almost every agent.** Search + booking | 60–90 s | Free auth, free search, no LetsFG booking fee |
 | **Developer API** ([letsfg.co/developers](https://letsfg.co/developers)) | Business / commercial / high-volume | 2–5 s (discover) · 60–90 s (full search) | Prepaid credits (monthly tiers — see below); direct booking URLs, no per-booking fee |
 
 **Quick decision:**
-- You want free search with no credits → **use the CLI / SDK** with a free PFS Bearer token (`letsfg auth`, described below).
+- You are an agent that wants to search and book → **use the CLI / SDK / MCP** with a PFS payment token (`letsfg auth`, described below). This is almost certainly you.
 - You need guaranteed speed for a product, or want direct booking URLs with no per-booking fee → **use the Developer API** at [letsfg.co/developers](https://letsfg.co/developers).
 
 > **Important:** `GET /en?q=...` does not work for automated agents. The website is protected by Cloudflare Turnstile. All agent/script access must use `POST /api/search` with a Bearer token.
@@ -58,17 +74,23 @@ Minimum top-up: $5. Register at [letsfg.co/developers](https://letsfg.co/develop
 
 Flight websites (Kayak, Google Flights, Expedia, Booking.com) also inflate prices based on demand tracking, cookie/session tracking, browser fingerprinting, and surge pricing. **LetsFG returns the raw airline price every time.**
 
-## Pricing Model
+## Pricing Model (PFS — what agents use)
 
 | Step | Cost | What You Get |
 |------|------|--------------|
-| **Search** | FREE | Price, times, duration, stops, airline category. Completely free, unlimited. No booking links. |
-| **Unlock** | 1% of ticket (min $3) | Airline name + direct booking URL. Pay via Stripe card **or** MPP crypto (no card needed). |
-| **Book** | Ticket price | Complete the booking directly on the airline's website using the booking URL. |
+| **Auth** | FREE | Zero-amount Stripe card setup. No charge, no authorization hold. |
+| **Search** | FREE, unlimited | Price, times, duration, stops, airline. |
+| **Book** | Ticket price only | Booked, or a direct booking link for that exact offer. No LetsFG fee. |
 
-**Two ways to pay for unlock — no setup required for MPP:**
-- **Stripe (card on file):** Run `letsfg setup-payment` once, then unlock charges your card automatically.
-- **MPP (agent-native crypto):** No card, no setup. The unlock endpoint issues a `402 Payment Required` with a `WWW-Authenticate: Payment` MPP challenge. Any MPP-compatible agent (Claude + pympp, mppx CLI, etc.) pays automatically in USDC.e on Tempo and retries — no human needed.
+LetsFG charges you nothing on this path. A completed booking pays the airline
+price with zero markup.
+
+> **Note on MPP / crypto payments.** Earlier versions of this document said the
+> unlock endpoint issues an MPP (Machine Payments Protocol) `402` challenge that
+> agents can settle in USDC.e on Tempo without a card. That is **not enabled in
+> production** — the server-side support exists but is unconfigured, so no MPP
+> challenge is ever issued. Do not build against it. The payment-token auth above
+> is the supported agent path.
 
 ## How It Works (3 Steps)
 
@@ -176,10 +198,10 @@ The booking URL takes you (or your user) directly to the airline's checkout with
 pip install letsfg
 ```
 
-This gives you the `letsfg` CLI command. Authenticate once with `letsfg auth` (free, uses Twitter/X), then search is free and unlimited:
+This gives you the `letsfg` CLI command. Authenticate once with `letsfg auth` (a zero-amount card setup (nothing charged)), then search is free and unlimited:
 
 ```bash
-# One-time auth (Twitter/X challenge → 90-day Bearer token)
+# One-time auth (card on file, nothing charged → 90-day Bearer token)
 letsfg auth
 
 # Search flights — completely free after auth
@@ -292,12 +314,12 @@ npx letsfg-mcp
 
 | Command | Description | Cost |
 |---------|-------------|------|
-| `letsfg auth` | One-time Twitter/X challenge → 90-day Bearer token (PFS access) | Free |
-| `letsfg register` | Get a Developer API key (prepaid credits, no per-booking fee) | Free |
+| `letsfg auth` | One-time card-on-file setup → 90-day Bearer token (PFS access). Nothing charged | Free |
+| `letsfg register` | **[Paid Developer API only — most agents should not run this]** Creates a billing account | Free |
 | `letsfg recover --email <email>` | Recover lost API key via email | Free |
 | `letsfg search <origin> <dest> <date>` | Search flights (no booking links) | Free |
 | `letsfg locations <query>` | Resolve city/airport to IATA | Free |
-| `letsfg setup-payment` | Add a payment card (one-time) | Free |
+| `letsfg setup-payment` | **[Paid Developer API only — use `letsfg auth` instead]** | Free |
 | `letsfg unlock <offer_id>` | Get direct airline booking URL | 1% of ticket, min $3 |
 | `letsfg me` | View profile & usage | Free |
 
@@ -1009,29 +1031,45 @@ curl -X POST https://letsfg.co/developers/api/v1/agents/register \
   -d '{"agent_name": "my-agent", "email": "you@example.com"}'
 ```
 
-## PFS Bearer Token Auth (Free — CLI / SDK / Direct API)
+## PFS Payment-Token Auth (CLI / SDK / Direct API)
 
-The CLI, Python SDK, and JS SDK all use the PFS (Programmatic Flight Search) Bearer token for authentication. This is the primary free access path — no email required, no payment, no credits. One-time Twitter/X challenge flow issues a 90-day token tied to your handle.
+The CLI, Python SDK, JS SDK and MCP server all use the PFS (Programmatic Flight
+Search) Bearer token. This is the access path for agents.
+
+**Nothing is charged to authenticate.** You put a payment method on file through
+a zero-amount Stripe setup — no charge, no authorization hold. That card is what
+lets your agent go all the way to booking. This replaced the Twitter/X challenge
+flow on 2026-07-29.
 
 **CLI (recommended):**
 ```bash
 letsfg auth
-# Opens Twitter/X challenge flow → saves token to ~/.letsfg/config.json
+# Opens Stripe's hosted card page → saves the token to ~/.letsfg/config.json
+
+# Headless — you already hold a Stripe credential, no browser needed:
+letsfg auth --payment-method pm_...
 ```
 
 **cURL (manual flow):**
 ```bash
-# Step 1: request a challenge
+# Step 1: ask how to enrol
 curl -s -X POST https://letsfg.co/api/agent-access/request
-# → {"challenge_code":"ABCD5678","expires_at":"...","tweet_text":"Challenge: ABCD5678 @LetsFG https://letsfg.co"}
+# → 402 {"setup_url":"https://checkout.stripe.com/c/pay/cs_...",
+#        "setup_session_id":"cs_...",
+#        "accepts":["setup_session_id","payment_method_id","card_token"],
+#        "charged":false}
 
-# Step 2: post the tweet_text from Step 1 using your Twitter/X account (public tweet, valid for 30 min)
-
-# Step 3: verify — submit the challenge_code to get your token
+# Step 2a: a human opens setup_url and adds a card, then:
 curl -s -X POST https://letsfg.co/api/agent-access/verify \
   -H "Content-Type: application/json" \
-  -d '{"challenge_code":"ABCD5678"}'
-# → {"token":"eyJ...","handle":"youraccount","expires_at":"2026-08-25T..."}
+  -d '{"setup_session_id":"cs_..."}'
+
+# Step 2b: OR, fully headless, if you already hold a Stripe credential:
+curl -s -X POST https://letsfg.co/api/agent-access/verify \
+  -H "Content-Type: application/json" \
+  -d '{"payment_method_id":"pm_..."}'
+
+# → {"token":"eyJ...","payer":"card:abc123","expires_at":"2026-10-27T...","charged":false}
 ```
 
 **Using the token:**
@@ -1044,11 +1082,32 @@ curl -X POST https://letsfg.co/api/search \
   -d '{"origin":"LHR","destination":"JFK","date_from":"2026-06-01"}'
 # → {"search_id":"abc123"}
 
-# Poll results (no auth needed)
-curl https://letsfg.co/api/results/abc123
+# Poll results
+curl https://letsfg.co/api/results/abc123 -H "Authorization: Bearer eyJ..."
+
+# Book
+curl -X POST https://letsfg.co/api/agent-book \
+  -H "Authorization: Bearer eyJ..." \
+  -H "Content-Type: application/json" \
+  -d '{"search_id":"abc123","offer_id":"ws_off_...","contact_email":"traveller@example.com",
+       "passenger":{"given_name":"Ada","family_name":"Lovelace","born_on":"1990-04-01",
+                    "gender":"f","phone_number":"+15551234567"}}'
 ```
 
-Token lifetime: 90 days. Renew by repeating the 3-step flow.
+Booking answers either `{"booked": true, "order_id": ...}` or
+`{"booked": false, "booking_url": ...}`. The second means the booking genuinely
+did not complete and **nothing was charged** — it is a normal outcome, not a
+transient error. Do not retry; give the user the `booking_url`, which goes to
+that exact offer. One passenger per call.
+
+Token lifetime: 90 days. One active token per card — re-enrolling the same card
+replaces the old token. Renew by running `letsfg auth` again.
+
+### Migrating from Twitter/X token auth
+
+Tokens issued through the old tweet challenge still work for now. Responses to
+them carry `Deprecation: true`, a `Warning` header, and a `Sunset` date once one
+is set. Re-run `letsfg auth` before that date.
 
 ## API Discovery
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1046,8 +1046,8 @@ flow on 2026-07-29.
 letsfg auth
 # Opens Stripe's hosted card page → saves the token to ~/.letsfg/config.json
 
-# Headless — you already hold a Stripe credential, no browser needed:
-letsfg auth --payment-method pm_...
+# Headless, no browser needed:
+letsfg auth --card-token tok_...
 ```
 
 **cURL (manual flow):**
@@ -1064,10 +1064,11 @@ curl -s -X POST https://letsfg.co/api/agent-access/verify \
   -H "Content-Type: application/json" \
   -d '{"setup_session_id":"cs_..."}'
 
-# Step 2b: OR, fully headless, if you already hold a Stripe credential:
+# Step 2b: OR, fully headless — mint a single-use card token against the
+#          LetsFG publishable key, then:
 curl -s -X POST https://letsfg.co/api/agent-access/verify \
   -H "Content-Type: application/json" \
-  -d '{"payment_method_id":"pm_..."}'
+  -d '{"card_token":"tok_..."}'
 
 # → {"token":"eyJ...","payer":"card:abc123","expires_at":"2026-10-27T...","charged":false}
 ```
@@ -1099,6 +1100,8 @@ Booking answers either `{"booked": true, "order_id": ...}` or
 did not complete and **nothing was charged** — it is a normal outcome, not a
 transient error. Do not retry; give the user the `booking_url`, which goes to
 that exact offer. One passenger per call.
+
+`payment_method_id` (pm_...) is accepted ONLY for a card already enrolled through this flow — a bare pm_ id is not proof that you control the card. For a first headless enrolment use `card_token` (tok_...), which you mint against the LetsFG publishable key.
 
 Token lifetime: 90 days. One active token per card — re-enrolling the same card
 replaces the old token. Renew by running `letsfg auth` again.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1103,8 +1103,14 @@ that exact offer. One passenger per call.
 
 `payment_method_id` (pm_...) is accepted ONLY for a card already enrolled through this flow — a bare pm_ id is not proof that you control the card. For a first headless enrolment use `card_token` (tok_...), which you mint against the LetsFG publishable key.
 
-Token lifetime: 90 days. One active token per card — re-enrolling the same card
-replaces the old token. Renew by running `letsfg auth` again.
+Token lifetime: 90 days.
+
+**One card = one agent.** A payment method identifies exactly one agent.
+Enrolling a card that is already in use does not create a second agent: it
+**replaces** the existing token and the old one stops working immediately. Two
+agents can never hold live tokens on the same card, so sharing or recycling a
+card gains you nothing. Quotas and rate limits are bucketed per card, not per
+token. Renew or rotate by running `letsfg auth` again.
 
 ### Migrating from Twitter/X token auth
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,13 @@ The flight connectors and backend API run server-side at letsfg.co (private repo
 
 | Mode | What it is | Speed | Cost |
 |------|-----------|-------|------|
-| **CLI / SDK** | `pip install letsfg` + `letsfg auth` — wraps PFS with auth and ranking | 60–90 s | Free search; unlock 1% of ticket (min $3) |
-| **PFS — Programmatic Flight Search** | Direct Bearer token → `POST /api/search` → poll `/api/results/<id>` | 60–90 s | Free search; unlock 1% (min $3) |
+| **CLI / SDK** | `pip install letsfg` + `letsfg auth` — wraps PFS with auth and ranking | 60–90 s | Free auth, free search, no LetsFG booking fee |
+| **PFS — Programmatic Flight Search** | Direct Bearer token → `POST /api/search` → poll `/api/results/<id>` → `POST /api/agent-book` | 60–90 s | Free auth, free search, no LetsFG booking fee |
 | **Developer API** | Prepaid credits, no per-booking fee, 2–5 s discover endpoint | 2–5 s (discover) · 60–90 s (full search) | Prepaid credits |
 
-Auth for CLI/PFS: one-time Twitter/X challenge (`letsfg auth`) → 90-day Bearer token.
+Auth for CLI/PFS: one-time payment-token enrolment (`letsfg auth`) → 90-day Bearer token.
+It is a **zero-amount** Stripe setup — the card is validated and vaulted, nothing is
+charged and no authorization hold is placed. Replaced the Twitter/X challenge 2026-07-29.
 
 ## Repository Structure
 
@@ -75,7 +77,7 @@ LetsFG/
 │   │   │   │   └── flights.py       # Pydantic models (FlightOffer, FlightSegment, etc.)
 │   │   │   └── connectors/
 │   │   │       ├── __init__.py
-│   │   │       └── auth.py          # Twitter/X challenge auth flow
+│   │   │       └── auth.py          # Payment-token auth flow (zero-amount card setup)
 │   │   ├── pyproject.toml
 │   │   └── README.md
 │   ├── js/                      # JS/TS SDK → npm: letsfg
@@ -100,21 +102,22 @@ LetsFG/
 
 ## Key Concepts
 
-### Three-Step Flow
+### Two-Step Flow (PFS — what agents use)
 1. **Search** (free) → `POST /api/search` with Bearer token → `search_id`; poll `GET /api/results/<search_id>` every 10 s
-2. **Unlock** (1% of ticket, min $3; free on Developer API) → confirms live price, reveals booking URL
-3. **Book** → complete booking on the airline's site via the returned URL
+2. **Book** → `POST /api/agent-book`. Either `{booked: true, order_id}` or
+   `{booked: false, booking_url}` — the latter means the booking genuinely did not
+   complete and **nothing was charged**; it is a normal outcome, not a retryable error.
 
 ### Search Architecture
 All flight data comes from the letsfg.co server-side engine. The SDK/CLI authenticates
-via a 90-day Bearer token obtained through the Twitter/X challenge flow and calls the
+via a 90-day Bearer token obtained through the payment-token enrolment flow and calls the
 cloud search API. No local browsers or scrapers are involved.
 
 Auth flow (one-time):
 ```
-POST /api/agent-access/request  → { challenge_code, tweet_text }
-# post tweet_text from your Twitter/X account
-POST /api/agent-access/verify   { challenge_code }  → { token, expires_at }
+POST /api/agent-access/request  → 402 { setup_url, setup_session_id, charged: false }
+# a human adds a card at setup_url, OR mint a single-use tok_ headlessly
+POST /api/agent-access/verify   { setup_session_id }  → { token, expires_at, charged: false }
 ```
 
 ### Open-Source Ranking Engine
@@ -133,8 +136,9 @@ The API returns raw prices with no demand-based inflation, cookie tracking, or s
 pricing. This is a core product principle.
 
 ### Free Search
-Search via PFS is always free. Unlock costs 1% of the ticket (min $3 Stripe charge).
-The prepaid Developer API returns direct booking URLs with no per-booking fee.
+Search via PFS is always free and unlimited, as is authentication (zero-amount card
+setup). LetsFG charges no fee on the PFS path at all. The prepaid Developer API is a
+separate paid product — do not send agents there by default.
 
 ### Real Passenger Details Required
 When booking, agents MUST provide real passenger email and legal name. Airlines send
@@ -203,11 +207,11 @@ npm publish
 ### PFS (Bearer token, free)
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/api/agent-access/request` | Start Twitter/X challenge → `{ challenge_code, tweet_text }` |
-| `POST` | `/api/agent-access/verify` | Verify challenge → `{ token, expires_at }` (90-day Bearer) |
+| `POST` | `/api/agent-access/request` | Start enrolment → 402 `{ setup_url, setup_session_id }` |
+| `POST` | `/api/agent-access/verify` | Present card → `{ token, expires_at }` (90-day Bearer) |
 | `POST` | `/api/search` | Start search → `{ search_id }` (Authorization: Bearer token) |
-| `GET`  | `/api/results/<search_id>` | Poll results (no auth required) |
-| `POST` | `/api/unlock` | Unlock offer → confirms live price + booking URL |
+| `GET`  | `/api/results/<search_id>` | Poll results (send the Bearer token) |
+| `POST` | `/api/agent-book` | Book an offer → booked, or a direct booking link. No LetsFG fee |
 
 ### Developer API (prepaid credits)
 Base: `https://letsfg.co/developers/api/v1`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+
+
+> **Correction (2026-07-29):** earlier revisions of this page described an MPP
+> (Machine Payments Protocol) `402` challenge letting agents pay in USDC.e on
+> Tempo with no card. That is **not enabled in production** — the server-side
+> support exists but is unconfigured, so no MPP challenge is ever issued. Do not
+> build against it.
+
+
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
 <div align="center">
 
 <a href="https://github.com/LetsFG/LetsFG">

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,6 +5,23 @@ description: "LetsFG — Agent-native flight search and booking API. Hundreds of
 
 # SKILL.md — LetsFG Capabilities
 
+> **Correction (2026-07-29):** earlier revisions of this page described an MPP
+> (Machine Payments Protocol) `402` challenge letting agents pay in USDC.e on
+> Tempo with no card. That is **not enabled in production** — the server-side
+> support exists but is unconfigured, so no MPP challenge is ever issued. Do not
+> build against it.
+
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 > Machine-readable skill manifest for AI agents and documentation indexers.
 ## Identity
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -146,10 +146,11 @@ curl -X POST https://letsfg.co/api/agent-access/verify \
   -H "Content-Type: application/json" \
   -d '{"setup_session_id":"cs_..."}'
 
-# 2b. OR fully headless, if you already hold a Stripe credential:
+# 2b. OR fully headless — mint a single-use card token against the LetsFG
+#     publishable key, then:
 curl -X POST https://letsfg.co/api/agent-access/verify \
   -H "Content-Type: application/json" \
-  -d '{"payment_method_id":"pm_..."}'
+  -d '{"card_token":"tok_..."}'
 # → {"token":"eyJ...","payer":"card:abc123","expires_at":"...","charged":false}
 
 # 3. Search with Bearer token (NL query)
@@ -163,6 +164,8 @@ curl -X POST https://letsfg.co/api/search \
 curl https://letsfg.co/api/results/ws_abc123 \
   -H "Authorization: Bearer eyJ..."
 ```
+
+`payment_method_id` (pm_...) is accepted ONLY for a card already enrolled through this flow — a bare pm_ id is not proof that you control the card. For a first headless enrolment use `card_token` (tok_...), which you mint against the LetsFG publishable key.
 
 Token is valid for 90 days; one active token per card. Renew by running `letsfg auth` again.
 Full walkthrough: https://letsfg.co/for-agents

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -1,12 +1,23 @@
 # Building AI Agents with LetsFG
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Guidelines for building autonomous AI agents that search, evaluate, and book flights. Works with OpenClaw, Perplexity Computer, Claude, Cursor, Windsurf, and any MCP-compatible agent framework.
 
 > 🎬 **[Watch the demo](https://github.com/LetsFG/LetsFG#demo-lfg-vs-default-agent-search)** — side-by-side comparison of default agent search vs LetsFG.
 
 ## Search
 
-All search runs server-side at letsfg.co. Authenticate once with `letsfg auth` (free 90-day Bearer token via Twitter/X) or use a prepaid Developer API key.
+All search runs server-side at letsfg.co. Authenticate once with `letsfg auth` (a zero-amount card setup (nothing charged), 90-day Bearer token) or use a prepaid Developer API key.
 
 ```python
 # PFS search — free Bearer token, server-side, 60-90 s
@@ -19,7 +30,7 @@ bt = LetsFG(api_key="trav_...")
 result = bt.search("LHR", "JFK", "2026-06-01")
 ```
 
-**When to use PFS (Bearer token):** Free search via Twitter/X authentication. 60–90 s per search. Unlock costs 1% of ticket (min $3). Run `letsfg auth` once.
+**When to use PFS (Bearer token):** This is the agent path — search and booking. Auth is a zero-amount card setup; nothing is charged. 60–90 s per search. Run `letsfg auth` once.
 
 **When to use Developer API:** Managed cloud search, billing controls, volume usage, and direct airline URLs with no per-booking fee. Register at [letsfg.co/developers](https://letsfg.co/developers).
 
@@ -118,36 +129,65 @@ The API has rate limits to ensure fair usage and protect airline endpoints.
 
 ### Programmatic access requires a Bearer token
 
-The letsfg.co website is for human users and is protected by Cloudflare Turnstile — plain HTTP requests or headless scripts cannot search it. Any agent or script that calls LetsFG directly must register a **free 90-day Bearer token** tied to a Twitter/X account. Registration takes ~2 minutes and requires no email or payment.
+The letsfg.co website is for human users and is protected by Cloudflare Turnstile — plain HTTP requests or headless scripts cannot search it. Any agent or script that calls LetsFG directly must hold a **90-day Bearer token**, obtained by putting a payment method on file.
 
-Once registered, use `POST /api/search` (natural language or structured) instead of `GET /en?q=...`.
+**Nothing is charged for this.** It is a zero-amount Stripe setup: the card is validated and vaulted, with no charge and no authorization hold. Having a card on file is what lets your agent go all the way to booking. This replaced the Twitter/X challenge on 2026-07-29.
+
+Once authenticated, use `POST /api/search` (natural language or structured) instead of `GET /en?q=...`.
 
 ```bash
-# 1. Get a challenge (no auth required)
+# 1. Ask how to enrol (no auth required)
 curl -X POST https://letsfg.co/api/agent-access/request
+# → 402 {"setup_url":"https://checkout.stripe.com/c/pay/cs_...",
+#        "setup_session_id":"cs_...","charged":false}
 
-# 2. Tweet the exact tweet_text from the response (public tweet, 30-min window)
-
-# 3. Verify and receive your Bearer token
+# 2a. A human opens setup_url and adds a card, then:
 curl -X POST https://letsfg.co/api/agent-access/verify \
   -H "Content-Type: application/json" \
-  -d '{"tweet_url":"https://twitter.com/you/status/...","challenge_signed":"eyJ..."}'
-# → {"token":"eyJ...","handle":"you","expires_at":"..."}
+  -d '{"setup_session_id":"cs_..."}'
 
-# 4. Search with Bearer token (NL query)
+# 2b. OR fully headless, if you already hold a Stripe credential:
+curl -X POST https://letsfg.co/api/agent-access/verify \
+  -H "Content-Type: application/json" \
+  -d '{"payment_method_id":"pm_..."}'
+# → {"token":"eyJ...","payer":"card:abc123","expires_at":"...","charged":false}
+
+# 3. Search with Bearer token (NL query)
 curl -X POST https://letsfg.co/api/search \
   -H "Authorization: Bearer eyJ..." \
   -H "Content-Type: application/json" \
   -d '{"query":"London to Barcelona June 15 2026"}'
 # → {"search_id":"ws_abc123","status":"searching","parsed":{...}}
 
-# 5. Poll for results
+# 4. Poll for results
 curl https://letsfg.co/api/results/ws_abc123 \
   -H "Authorization: Bearer eyJ..."
 ```
 
-Token is valid for 90 days. Renew by repeating the challenge/tweet/verify flow.
-Full registration walkthrough: https://letsfg.co/for-agents
+Token is valid for 90 days; one active token per card. Renew by running `letsfg auth` again.
+Full walkthrough: https://letsfg.co/for-agents
+
+### Booking
+
+```bash
+curl -X POST https://letsfg.co/api/agent-book \
+  -H "Authorization: Bearer eyJ..." \
+  -H "Content-Type: application/json" \
+  -d '{"search_id":"ws_abc123","offer_id":"ws_off_...",
+       "contact_email":"traveller@example.com",
+       "passenger":{"given_name":"Ada","family_name":"Lovelace",
+                    "born_on":"1990-04-01","gender":"f","phone_number":"+15551234567"}}'
+```
+
+Two outcomes, both with `"charged": 0`:
+
+- `{"booked": true, "order_id": "..."}` — booked.
+- `{"booked": false, "booking_url": "..."}` — the booking genuinely did not
+  complete and nothing was charged. **This is a normal outcome, not a transient
+  error.** Retrying will not book it. Hand the user `booking_url`; it goes to
+  that exact offer.
+
+One passenger per call.
 
 Handle rate limits and timeouts in production:
 

--- a/docs/api-errors.md
+++ b/docs/api-errors.md
@@ -1,5 +1,16 @@
 # Errors and Limits
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 <div class="docs-callout">
   <strong>Most paid API failures are state failures.</strong> In practice, the search path breaks more often because the account is not ready than because the request body is malformed. Treat <code>GET /agents/me</code> as the source of truth before you send paid search traffic.
 </div>

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -1,5 +1,16 @@
 # Public Developer API
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 <div class="docs-callout">
     <strong>Scope:</strong> this section is only about the website-owned public REST API at <code>https://letsfg.co/developers/api/v1</code>. Local SDK and CLI search still stay free and do not require the paid public onboarding flow.
 </div>

--- a/docs/api-onboarding.md
+++ b/docs/api-onboarding.md
@@ -1,5 +1,16 @@
 # Onboarding and Billing
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 <div class="docs-callout">
   <strong>Two valid paths:</strong> use the browserless API-only flow when you already have a Stripe-generated <code>payment_method_id</code> or <code>token</code>, or use hosted checkout when a browser is available and you want LetsFG to handle the Stripe UI.
 </div>

--- a/docs/api-polling.md
+++ b/docs/api-polling.md
@@ -1,5 +1,16 @@
 # Async Search and Polling
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 The standard `POST /flights/search` blocks until results are ready (60–90 seconds).
 If your product needs to show a loading state while results arrive, use the async
 flow: start the search immediately, then poll for updates.

--- a/docs/api-sandbox.md
+++ b/docs/api-sandbox.md
@@ -1,5 +1,16 @@
 # Sandbox Environment
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Test your integration without consuming prepaid balance or firing real connectors.
 The sandbox mirrors the full Developer API surface — same endpoints, same request
 schema, same response schema — but returns realistic fake data instantly.

--- a/docs/api-search.md
+++ b/docs/api-search.md
@@ -1,5 +1,16 @@
 # Search and Results
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 <div class="docs-callout">
   <strong>Paid search rule:</strong> the public developer API search endpoint consumes prepaid balance. Use local search when you want broad free exploration, and use the public API when you want managed cloud search behind the website-owned contract.
 </div>

--- a/docs/architecture-guide.md
+++ b/docs/architecture-guide.md
@@ -1,5 +1,16 @@
 # Architecture & Resilience Guide
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Deep dive into how LetsFG's server-side search engine works — connector orchestration, failure handling, caching strategies, and performance optimization. All search runs on letsfg.co infrastructure.
 
 ## Search Engine Architecture

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,16 @@
 # CLI Reference
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 The `letsfg` CLI is available via both Python and JavaScript. Same commands, same interface.
 
 ## Install
@@ -22,7 +33,7 @@ The `letsfg` CLI is available via both Python and JavaScript. Same commands, sam
 |---------|-------------|
 | `letsfg register` | Create account and get API key |
 | `letsfg recover --email <email>` | Recover lost API key via email verification |
-| `letsfg auth` | Authenticate via Twitter/X challenge to get a free 90-day Bearer token |
+| `letsfg auth` | Put a card on file (zero-amount, nothing charged) to get a 90-day Bearer token |
 | `letsfg search <origin> <dest> <date>` | Search flights via the letsfg.co server-side engine (free with Bearer token) |
 | `letsfg locations <query>` | Resolve city/airport to IATA codes |
 | `letsfg unlock <offer_id>` | Unlock offer details (payment required) |
@@ -159,6 +170,6 @@ The code expires in 15 minutes. Once verified, a new API key is issued and your 
 
 | Variable | Description |
 |----------|-------------|
-| `LETSFG_BEARER_TOKEN` | Bearer token from `letsfg auth` (free PFS search via Twitter/X) |
+| `LETSFG_BEARER_TOKEN` | Bearer token from `letsfg auth` (PFS search + booking) |
 | `LETSFG_API_KEY` | Developer API key for prepaid account search, unlock, and book |
 | `LETSFG_BASE_URL` | API URL override (default: `https://letsfg.co/developers`) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ letsfg auth
 
 This opens Stripe's hosted card page. Add a card — it is a zero-amount setup, so nothing is charged and no authorization hold is placed — then confirm. Your 90-day Bearer token is saved automatically. Renew by repeating this step.
 
-Already hold a Stripe credential? Skip the browser: `letsfg auth --payment-method pm_...`
+No browser available? Mint a single-use card token against the LetsFG publishable key and skip the hosted page: `letsfg auth --card-token tok_...`
 
 ### 3. Run the first search
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,16 @@
 # Getting Started
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 <div class="docs-callout">
   <strong>Pick the correct path first.</strong> Use Option A (free Bearer token) if you want search with no credit card. Use Option B (Developer API) if you want direct airline booking URLs or managed billing.
 </div>
@@ -27,7 +38,9 @@ pip install letsfg
 letsfg auth
 ```
 
-This starts the Twitter/X challenge flow. Post the provided tweet from your account, then confirm. Your 90-day Bearer token is saved automatically. Renew by repeating this step.
+This opens Stripe's hosted card page. Add a card — it is a zero-amount setup, so nothing is charged and no authorization hold is placed — then confirm. Your 90-day Bearer token is saved automatically. Renew by repeating this step.
+
+Already hold a Stripe credential? Skip the browser: `letsfg auth --payment-method pm_...`
 
 ### 3. Run the first search
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,17 @@ hide:
   - toc
 ---
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 <section class="docs-hero">
   <div class="docs-hero-inner">
     <p class="docs-kicker">Official LetsFG documentation</p>
@@ -30,7 +41,7 @@ LetsFG has two access paths — pick the one that matches your setup:
 
 | Path | How | Speed | Search cost | Booking URL |
 |------|-----|-------|-------------|-------------|
-| **CLI / SDK** (`letsfg auth`) | Server-side search via the letsfg.co engine; one-time Twitter/X challenge → 90-day Bearer token | 60–90 s | Free | 1% concierge fee (min $3) via letsfg.co |
+| **CLI / SDK** (`letsfg auth`) | Server-side search + booking; one-time zero-amount card setup → 90-day Bearer token | 60–90 s | Free | No LetsFG fee |
 | **Developer API** ([letsfg.co/developers](https://letsfg.co/developers)) | Runs on our servers with prepaid credits | 2–5 s (discover) · 60–90 s (full search) | Prepaid credits | Direct airline booking URLs, no per-booking fee |
 
 **When to choose each:**
@@ -45,7 +56,7 @@ LetsFG has two access paths — pick the one that matches your setup:
   <article class="docs-mode-card">
     <p class="docs-card-kicker">CLI / SDK mode</p>
     <h2>Search free after a one-time auth step</h2>
-    <p>Use this path after installing the SDK. Run <code>letsfg auth</code> once to complete the Twitter/X challenge and get a 90-day Bearer token. All search runs server-side at letsfg.co — no local browsers required.</p>
+    <p>Use this path after installing the SDK. Run <code>letsfg auth</code> once to put a card on file (nothing is charged) and get a 90-day Bearer token. All search runs server-side at letsfg.co — no local browsers required.</p>
     <ul class="docs-check-list">
       <li><code>letsfg search</code> and <code>bt.search()</code> work with the Bearer token</li>
       <li>Search is free and unlimited for the 90-day token lifetime</li>

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,5 +1,16 @@
 # OpenAPI and Swagger
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 <div class="docs-callout">
   <strong>Use the website-owned schema.</strong> The canonical public contract lives at <code>https://letsfg.co/developers/api/openapi.json</code>. Treat that as the live machine-readable surface, not the old raw repository link.
 </div>

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,5 +1,16 @@
 # Packages
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 LetsFG is available as a Python SDK, JavaScript SDK, MCP server, and remote MCP endpoint. Works with OpenClaw, Perplexity Computer, Claude Desktop, Cursor, Windsurf, and any MCP-compatible agent.
 
 ## Overview

--- a/docs/quickstart-claude.md
+++ b/docs/quickstart-claude.md
@@ -1,5 +1,16 @@
 # Claude Desktop — 5-Minute Quickstart
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Choose between the paid remote MCP endpoint and the free local MCP server.
 
 ---
@@ -72,7 +83,7 @@ pip install letsfg
 letsfg auth
 ```
 
-`letsfg auth` walks you through the Twitter/X challenge and saves a 90-day Bearer token.
+`letsfg auth` puts a card on file (zero-amount, nothing charged) and saves a 90-day Bearer token.
 
 ### 2. Add to Claude Desktop config
 

--- a/docs/quickstart-cursor.md
+++ b/docs/quickstart-cursor.md
@@ -1,5 +1,16 @@
 # Cursor — 5-Minute Quickstart
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Choose between the paid remote MCP endpoint and the free local MCP server.
 
 ---
@@ -63,7 +74,7 @@ pip install letsfg
 letsfg auth
 ```
 
-`letsfg auth` walks you through the Twitter/X challenge and saves a 90-day Bearer token.
+`letsfg auth` puts a card on file (zero-amount, nothing charged) and saves a 90-day Bearer token.
 
 ### 2. Add to `.cursor/mcp.json`
 

--- a/docs/quickstart-windsurf.md
+++ b/docs/quickstart-windsurf.md
@@ -1,5 +1,16 @@
 # Windsurf — 5-Minute Quickstart
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Choose between the paid remote MCP endpoint and the free local MCP server.
 
 ---
@@ -63,7 +74,7 @@ pip install letsfg
 letsfg auth
 ```
 
-`letsfg auth` walks you through the Twitter/X challenge and saves a 90-day Bearer token.
+`letsfg auth` puts a card on file (zero-amount, nothing charged) and saves a 90-day Bearer token.
 
 ### 2. Edit `~/.codeium/windsurf/mcp_config.json`
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,5 +1,16 @@
 # Integration Tutorials
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Practical guides for building travel applications with LetsFG in Python and JavaScript/TypeScript.
 
 ## Python: Concurrent Multi-Route Search

--- a/sdk/js/src/cli.ts
+++ b/sdk/js/src/cli.ts
@@ -316,16 +316,21 @@ const HELP = `
 LetsFG — Agent-native flight search & booking.
 
 Search hundreds of airlines via the LetsFG cloud engine.
-Free search: authenticate once with Twitter/X, then search instantly.
+Authenticate once with letsfg auth — a zero-amount card setup, nothing is
+charged — then search and book.
 
 Commands:
+  auth                            Put a card on file -> 90-day token. Nothing charged
   search <origin> <dest> <date>   Search for flights (free)
   locations <query>               Resolve city name to IATA codes
-  unlock <offer_id>               Unlock offer — 1% of ticket (min $3)
-  book <offer_id> --passenger ... Book flight — charges ticket price via Stripe
-  register --name ... --email ... Register for a Developer API key
-  setup-payment                   Attach Stripe payment method
+  book <offer_id> --passenger ... Book a flight. No LetsFG fee
   me                              Show agent profile
+
+Developer API only (a SEPARATE paid product — most agents should not use these;
+they create a billing account. Use auth above instead):
+  register --name ... --email ... Create a paid Developer API account
+  setup-payment                   Attach a card to that paid account
+  unlock <offer_id>               Unlock offer — 1% of ticket (min $3)
 
 Options:
   --json, -j       Output raw JSON
@@ -333,10 +338,9 @@ Options:
   --base-url       API URL (default: https://letsfg.co/developers)
 
 Examples:
-  letsfg register --name my-agent --email me@example.com
+  letsfg auth
   letsfg search GDN BER 2026-03-03 --sort price
-  letsfg unlock off_xxx
-  letsfg book off_xxx -p '{"id":"pas_xxx",...}' -e john@ex.com
+  letsfg book off_xxx -p '{"given_name":"Ada",...}' -e ada@example.com
 `;
 
 async function main() {

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -441,7 +441,11 @@ export class LetsFG {
   }
 
   /**
-   * Set up payment method (required before unlock/booking).
+   * [Developer API only] Attach a card to a PAID prepaid Developer API account.
+   *
+   * Most agents should NOT call this. It is unrelated to authenticating for
+   * search and booking — for that, run `letsfg auth`, which puts a card on file
+   * through a zero-amount setup and creates no billing account.
    */
   async setupPayment(token = 'tok_visa'): Promise<Record<string, unknown>> {
     this.requireApiKey();
@@ -459,7 +463,10 @@ export class LetsFG {
   // ── Static methods ───────────────────────────────────────────────────
 
   /**
-   * Register a new Developer API agent — no auth needed.
+   * [Developer API only] Create a PAID Developer API account with its own billing.
+   *
+   * Most agents should NOT call this — it creates a billing account you probably
+   * do not want. To search and book flights, run `letsfg auth` instead.
    */
   static async register(
     agentName: string,

--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -256,15 +256,16 @@ const TOOLS = [
       'a zero-amount Stripe setup, no charge and no authorization hold. Call once.\n\n' +
       'Call with no arguments to start: returns a setup_url for the user to add a card, plus a ' +
       'setup_session_id. Call again with that setup_session_id once they are done to receive the token. ' +
-      'If you already hold a Stripe credential for this account, pass payment_method_id or card_token ' +
-      'instead and skip the browser entirely.\n\n' +
+      'For a fully headless enrolment, mint a single-use card token against the LetsFG publishable ' +
+      'key and pass card_token instead, skipping the browser entirely. payment_method_id is accepted ' +
+      'ONLY for a card already enrolled through this flow — a bare pm_ id is not proof of card control.\n\n' +
       'This does NOT create a Developer API billing account. Do not use setup_payment for this.',
     inputSchema: {
       type: 'object',
       properties: {
         setup_session_id: { type: 'string', description: 'cs_... from a previous authenticate call, after the card was added' },
-        payment_method_id: { type: 'string', description: 'Stripe pm_... you already hold' },
-        card_token: { type: 'string', description: 'Stripe tok_... you already hold' },
+        payment_method_id: { type: 'string', description: 'Stripe pm_... for a card ALREADY enrolled through this flow (re-issue only)' },
+        card_token: { type: 'string', description: 'Single-use Stripe tok_... minted against the LetsFG publishable key — the headless path' },
       },
     },
   },

--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -56,7 +56,12 @@ async function searchPFS(params: Record<string, unknown>): Promise<Record<string
   while (Date.now() < deadline) {
     await new Promise(r => setTimeout(r, PFS_POLL_INTERVAL_MS));
     const pollResp = await fetch(`${BASE_URL}/api/results/${search_id}`, {
-      headers: { 'User-Agent': `letsfg-mcp/${VERSION}` },
+      // Carry the token on the poll too, not just the POST: results are the
+      // agent's own, and the token is what buckets rate limiting to this agent.
+      headers: {
+        'User-Agent': `letsfg-mcp/${VERSION}`,
+        'Authorization': `Bearer ${BEARER_TOKEN}`,
+      },
     });
     if (pollResp.ok) {
       const result = await pollResp.json() as Record<string, unknown>;
@@ -106,39 +111,35 @@ async function resolveLocationCloud(query: string): Promise<unknown> {
 const GUIDE_TEXT =
   '# LetsFG — Flight Search & Booking Guide\n' +
   '\n' +
-  '## How It Works (3-Step Flow)\n' +
-  '1. **search_flights** (FREE, unlimited) — Searches hundreds of airlines server-side. Returns prices, airlines, times, durations, stopovers. Requires Bearer token or API key.\n' +
-  '2. **unlock_flight_offer** (1% fee, min $3) — Confirms live price with the airline. Reserves offer for 30 minutes. Charges via Stripe card or MPP crypto.\n' +
-  '3. **book_flight** (ticket price only, Developer API only) — Creates real airline reservation with PNR. Charges ticket price via Stripe.\n' +
+  '## How It Works (2-Step Flow)\n' +
+  '1. **search_flights** (FREE, unlimited) — Searches hundreds of airlines server-side. Returns prices, airlines, times, durations, stopovers.\n' +
+  '2. **book_flight** — Books the offer. If we cannot complete it, you get a direct booking link for that exact offer instead. Nothing is charged by LetsFG either way.\n' +
   '\n' +
   '## Authentication\n' +
-  '- **PFS Bearer token** (free): Run `letsfg auth` to get a 90-day token via Twitter/X challenge. Set LETSFG_BEARER_TOKEN.\n' +
-  '- **Developer API key** (prepaid credits): Register at letsfg.co/developers. Set LETSFG_API_KEY. Enables book_flight and no per-booking fee on unlock.\n' +
+  'Run `letsfg auth`, or call the **authenticate** tool. It puts a payment method on file through a zero-amount Stripe setup — no charge, no authorization hold — and returns a 90-day token. Set LETSFG_BEARER_TOKEN.\n' +
+  '\n' +
+  '## DO NOT create a Developer API account\n' +
+  'Do NOT call /developers/api/v1/agents/register or /developers/api/v1/agents/setup-payment, and do NOT run `letsfg register` or `letsfg setup-payment`. Those belong to a SEPARATE paid, prepaid-balance product for high-volume commercial integrations, and they create a billing account you almost certainly do not want. Older versions of these docs pointed there by default; that was wrong. Use the payment-token auth above.\n' +
   '\n' +
   '## Pricing\n' +
+  '- Auth: FREE — zero-amount card setup, nothing charged\n' +
   '- Search: FREE, unlimited\n' +
-  '- Unlock: 1% of ticket price (min $3) — Stripe card or MPP crypto. Free with Developer API.\n' +
-  '- Book: Exact airline price + Stripe processing fee. Zero markup. Developer API only.\n' +
+  '- Book: Ticket price only, at the airline price. No LetsFG fee, no markup.\n' +
   '\n' +
   '## Critical Rules\n' +
   '- **Resolve locations first**: City names are ambiguous. "London" = 5+ airports. Use resolve_location to get IATA codes before searching.\n' +
   '- **Real passenger details REQUIRED**: Airlines send e-tickets to the email provided. Names must match passport/government ID exactly. NEVER use placeholder emails, agent emails, or fake names.\n' +
-  '- **Idempotency keys for booking**: Always provide idempotency_key when calling book_flight to prevent double-bookings on retry.\n' +
-  '- **Price changes**: The unlock step confirms the real-time airline price, which may differ from search. Always inform the user if confirmed_price differs.\n' +
-  '- **30-minute window**: After unlock, the offer is held for 30 minutes. If expired, search + unlock again.\n' +
-  '\n' +
-  '## Passenger ID Mapping\n' +
-  'Search returns passenger_ids (e.g., ["pas_0", "pas_1"]). When booking, each passenger object must include the matching "id" field from this list.\n' +
+  '- **booking_unavailable is normal, not an error**: when book_flight answers {"booked": false, "booking_url": "..."}, the booking genuinely did not complete and retrying will not change that. Give the user the booking_url — it goes to that exact offer.\n' +
+  '- **Offers expire with the search** (~15 min). If an offer is gone, search again.\n' +
   '\n' +
   '## Error Handling\n' +
   '- **transient** errors (SUPPLIER_TIMEOUT, RATE_LIMITED, SERVICE_UNAVAILABLE): Safe to retry after 1-5 seconds\n' +
   '- **validation** errors (INVALID_IATA, INVALID_DATE, MISSING_PARAMETER): Fix the input, then retry\n' +
-  '- **business** errors (OFFER_EXPIRED, PAYMENT_DECLINED, OFFER_NOT_UNLOCKED): Requires human decision — do not auto-retry\n' +
+  '- **business** errors (OFFER_EXPIRED, PAYMENT_DECLINED): Requires human decision — do not auto-retry\n' +
   '\n' +
   '## Search Tips\n' +
   '- Search is free — search multiple dates, cabin classes, airport combos liberally\n' +
   '- Search takes 60-90s (async: POST /api/search -> poll /api/results/<id> every 10s)\n' +
-  '- Filter search results (stops, duration, airline) before unlocking\n' +
   '- Covers hundreds of airlines across all continents including low-cost carriers\n';
 
 const RESOURCES = [
@@ -212,17 +213,19 @@ const TOOLS = [
   {
     name: 'book_flight',
     description:
-      'Book an unlocked flight — creates real airline reservation with PNR (step 3 of 3). Developer API only.\n\n' +
-      'FLOW: search_flights -> unlock_flight_offer -> setup_payment (once) -> book_flight\n' +
-      'CHARGES: Ticket price via Stripe (2.9% + 30c processing). Zero markup.\n' +
-      'SAFETY: Always provide idempotency_key to prevent double-bookings. Use REAL passenger details — ' +
-      'names must match passport, email receives the e-ticket.\n\n' +
-      'Errors include error_code/error_category: transient -> retry, validation -> fix input, business -> ask user.',
+      'Book a flight from a search result.\n\n' +
+      'FLOW: authenticate (once) -> search_flights -> book_flight\n' +
+      'CHARGES: nothing from LetsFG. A completed booking pays the airline price with zero markup.\n' +
+      'RESULT: either {"booked": true, "order_id": "..."} or {"booked": false, "booking_url": "..."} — ' +
+      'the second means the booking genuinely did not complete and nothing was charged. That is a normal ' +
+      'outcome, NOT a transient error: do not retry, give the user the booking_url.\n' +
+      'SAFETY: use REAL passenger details — names must match passport, email receives the e-ticket.',
     inputSchema: {
       type: 'object',
-      required: ['offer_id', 'passengers', 'contact_email'],
+      required: ['search_id', 'offer_id', 'passengers', 'contact_email'],
       properties: {
-        offer_id: { type: 'string', description: "Unlocked offer ID (off_xxx)" },
+        search_id: { type: 'string', description: 'search_id from search_flights' },
+        offer_id: { type: 'string', description: 'Offer ID from search_flights' },
         passengers: {
           type: 'array',
           description: "Passengers with 'id' from search passenger_ids",
@@ -247,8 +250,30 @@ const TOOLS = [
     },
   },
   {
+    name: 'authenticate',
+    description:
+      'Get a LetsFG token by putting a payment method on file. Nothing is charged — ' +
+      'a zero-amount Stripe setup, no charge and no authorization hold. Call once.\n\n' +
+      'Call with no arguments to start: returns a setup_url for the user to add a card, plus a ' +
+      'setup_session_id. Call again with that setup_session_id once they are done to receive the token. ' +
+      'If you already hold a Stripe credential for this account, pass payment_method_id or card_token ' +
+      'instead and skip the browser entirely.\n\n' +
+      'This does NOT create a Developer API billing account. Do not use setup_payment for this.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        setup_session_id: { type: 'string', description: 'cs_... from a previous authenticate call, after the card was added' },
+        payment_method_id: { type: 'string', description: 'Stripe pm_... you already hold' },
+        card_token: { type: 'string', description: 'Stripe tok_... you already hold' },
+      },
+    },
+  },
+  {
     name: 'setup_payment',
-    description: 'Attach a payment card (required before booking). Free to attach. Only needs to be called once.',
+    description:
+      '[Developer API only — you almost certainly want `authenticate` instead] Attaches a card to a ' +
+      'PAID prepaid Developer API account. Refuses to run unless LETSFG_API_KEY is set, because agents ' +
+      'kept calling this and creating billing accounts they did not need.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -343,6 +368,31 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<st
     }
 
     case 'book_flight': {
+      // Bearer token → PFS booking. Only an explicit Developer API key routes to
+      // the paid booking endpoint, so the default agent never touches it.
+      if (BEARER_TOKEN) {
+        const passengers = (args.passengers || []) as Array<Record<string, unknown>>;
+        // /api/agent-book takes one passenger. Silently booking only the first
+        // of several would hand back a confirmation for a trip nobody asked for,
+        // so refuse instead of truncating.
+        if (passengers.length > 1) {
+          return JSON.stringify({
+            error: 'multi_passenger_unsupported',
+            detail:
+              `Booking supports one passenger per call and ${passengers.length} were supplied. ` +
+              'Nothing was booked. Book each passenger separately, or send the user to the ' +
+              'booking_url from a single-passenger call.',
+          }, null, 2);
+        }
+        const body: Record<string, unknown> = {
+          search_id: args.search_id,
+          offer_id: args.offer_id,
+          contact_email: args.contact_email,
+          passenger: passengers[0],
+        };
+        const result = await apiRequest('POST', '/api/agent-book', body) as Record<string, unknown>;
+        return JSON.stringify(result, null, 2);
+      }
       const body: Record<string, unknown> = {
         offer_id: args.offer_id,
         booking_type: 'flight',
@@ -354,7 +404,40 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<st
       return JSON.stringify(result, null, 2);
     }
 
+    case 'authenticate': {
+      if (args.setup_session_id || args.payment_method_id || args.card_token) {
+        const body: Record<string, unknown> = {};
+        if (args.setup_session_id) body.setup_session_id = args.setup_session_id;
+        if (args.payment_method_id) body.payment_method_id = args.payment_method_id;
+        if (args.card_token) body.card_token = args.card_token;
+        const result = await apiRequest('POST', '/api/agent-access/verify', body) as Record<string, unknown>;
+        if (!result.error && result.token) {
+          return JSON.stringify({
+            ...result,
+            next: 'Set LETSFG_BEARER_TOKEN to this token and restart the MCP server.',
+          }, null, 2);
+        }
+        return JSON.stringify(result, null, 2);
+      }
+      // apiRequest treats the 402 as an error envelope; call directly so the
+      // agent sees setup_url, which is the whole point of the response.
+      const resp = await fetch(`${BASE_URL}/api/agent-access/request`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'User-Agent': `letsfg-mcp/${VERSION}` },
+        body: '{}',
+      });
+      return JSON.stringify(await resp.json(), null, 2);
+    }
+
     case 'setup_payment': {
+      if (!API_KEY) {
+        return JSON.stringify({
+          error: 'wrong_tool',
+          detail:
+            'setup_payment attaches a card to a PAID Developer API account and is not how agents authenticate. ' +
+            'Use the `authenticate` tool instead — nothing is charged and no billing account is created.',
+        }, null, 2);
+      }
       const body: Record<string, unknown> = {};
       if (args.token) body.token = args.token;
       if (args.payment_method_id) body.payment_method_id = args.payment_method_id;

--- a/sdk/python/letsfg/__init__.py
+++ b/sdk/python/letsfg/__init__.py
@@ -43,7 +43,7 @@ from letsfg.models import (
 )
 from letsfg.models.flights import PublicFlightOffer, to_public_offer
 
-__version__ = "2026.5.80"
+__version__ = "2026.5.81"
 __all__ = [
     "LetsFG",
     "LetsFGError",

--- a/sdk/python/letsfg/cli.py
+++ b/sdk/python/letsfg/cli.py
@@ -86,6 +86,24 @@ def _err(msg: str):
         console.print(f"[red]Error:[/red] {msg}")
     else:
         print(f"Error: {msg}", file=sys.stderr)
+
+
+def _warn_developer_api_command(cmd: str):
+    """Loud, non-fatal notice on the paid Developer API commands.
+
+    Agents kept reaching for these because our own docs pointed here by default,
+    quietly creating billing accounts nobody wanted. Searching and booking need
+    `letsfg auth` and nothing else.
+    """
+    msg = (
+        f"'{cmd}' is for the PAID Developer API and creates a billing account.\n"
+        "  If you just want to search or book flights, press Ctrl+C and run: letsfg auth\n"
+        "  (one step, no billing account, nothing charged)"
+    )
+    if HAS_RICH:
+        console.print(f"[yellow]Note:[/yellow] {msg}")
+    else:
+        print(f"Note: {msg}", file=sys.stderr)
     raise typer.Exit(1)
 
 
@@ -484,15 +502,41 @@ def search(
 
 
 @app.command()
-def auth():
-    """Authenticate via Twitter/X — free, one-time, 90-day token.
+def auth(
+    payment_method_id: Optional[str] = typer.Option(
+        None, "--payment-method", help="Stripe pm_... you already hold (headless, no browser)"
+    ),
+    card_token: Optional[str] = typer.Option(
+        None, "--card-token", help="Stripe tok_... you already hold (headless, no browser)"
+    ),
+    setup_session_id: Optional[str] = typer.Option(
+        None, "--setup-session", help="Finish an enrolment already started (cs_...)"
+    ),
+):
+    """Authenticate — one-time, 90-day token. Nothing is charged.
 
-    Posts a one-time challenge to verify your Twitter/X account.
-    Token is saved locally and reused automatically for 90 days.
+    Adds a payment method on file via a zero-amount Stripe setup (no charge, no
+    authorization hold). That card is what lets your agent book, and it replaces
+    the Twitter/X challenge retired 2026-07-29.
+
+    Unrelated to `letsfg register` / `letsfg setup-payment`, which belong to the
+    separate paid Developer API.
     """
-    from letsfg.connectors.auth import twitter_auth, BearerTokenError
+    from letsfg.connectors.auth import (
+        payment_auth,
+        verify_payment_method,
+        BearerTokenError,
+    )
     try:
-        twitter_auth()
+        if payment_method_id or card_token or setup_session_id:
+            verify_payment_method(
+                setup_session_id=setup_session_id,
+                payment_method_id=payment_method_id,
+                card_token=card_token,
+            )
+            print("\n  ✓ Authenticated. Nothing was charged.")
+        else:
+            payment_auth()
         print("\n  You're all set. Run: letsfg search WAW BCN 2026-07-15\n")
     except BearerTokenError as e:
         _err(str(e))
@@ -637,7 +681,13 @@ def register(
     output_json: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
     base_url: Optional[str] = typer.Option(None, "--base-url", envvar="LETSFG_BASE_URL"),
 ):
-    """Register a new agent — get your API key for the Developer API."""
+    """[Developer API only] Create a PAID developer account with its own billing.
+
+    Most agents do NOT need this. To search and book flights, run `letsfg auth`
+    instead — it takes one step and creates no billing account. This command
+    exists for high-volume commercial integrations on the prepaid Developer API.
+    """
+    _warn_developer_api_command("letsfg register")
     try:
         result = LetsFG.register(
             agent_name=name,
@@ -771,7 +821,12 @@ def setup_payment(
     api_key: Optional[str] = typer.Option(None, "--api-key", "-k", envvar="LETSFG_API_KEY"),
     base_url: Optional[str] = typer.Option(None, "--base-url", envvar="LETSFG_BASE_URL"),
 ):
-    """Set up payment method (required before booking)."""
+    """[Developer API only] Attach a card to a PAID developer account.
+
+    Most agents do NOT need this. `letsfg auth` already puts a payment method on
+    file for search and booking, without a billing account.
+    """
+    _warn_developer_api_command("letsfg setup-payment")
     bt = _get_client(api_key, base_url)
     try:
         result = bt.setup_payment(token=token)

--- a/sdk/python/letsfg/connectors/auth.py
+++ b/sdk/python/letsfg/connectors/auth.py
@@ -1,19 +1,37 @@
 """
-Twitter/X authentication for LetsFG Programmatic Flight Search (PFS).
+Payment-token authentication for LetsFG Programmatic Flight Search (PFS).
 
-Flow (one-time, ~30 seconds):
+PFS requires a payment method on file. Nothing is charged to authenticate — it
+is a zero-amount Stripe setup that validates and vaults a card, with no charge
+and no authorization hold. Having a card on file is what lets your agent go all
+the way to booking.
+
+Flow (one-time):
   1. POST https://letsfg.co/api/agent-access/request
-     → { challenge_code, tweet_text, expires_at }
-  2. Post the tweet_text from your Twitter/X account.
-  3. POST https://letsfg.co/api/agent-access/verify  { challenge_code }
-     → { token, expires_at }   (90-day Bearer token)
+     → 402 { setup_url, setup_session_id, accepts, verify_url }
+  2. Present a payment method, either:
+       hosted   — a human opens setup_url and adds a card, then you send
+                  { "setup_session_id": "cs_..." }
+       headless — you already hold a Stripe credential, so send
+                  { "payment_method_id": "pm_..." } or { "card_token": "tok_..." }
+  3. POST https://letsfg.co/api/agent-access/verify
+     → { token, payer, expires_at }   (90-day Bearer token)
 
-After that, every search call uses:
+After that, every call uses:
     Authorization: Bearer <token>
     POST https://letsfg.co/api/search
     GET  https://letsfg.co/api/results/<search_id>
+    POST https://letsfg.co/api/agent-book
 
-Run `letsfg auth` to do all of this interactively.
+Run `letsfg auth` to do this interactively.
+
+This replaces the Twitter/X challenge flow, retired 2026-07-29. Tokens issued
+that way keep working until the announced sunset date; re-run `letsfg auth` to
+move over.
+
+NOTE: this has nothing to do with `letsfg register` / `letsfg setup-payment`,
+which belong to the separate, paid Developer API and create a billing account
+most agents do not want.
 """
 
 from __future__ import annotations
@@ -21,6 +39,7 @@ from __future__ import annotations
 import json
 import os
 import time
+import webbrowser
 from pathlib import Path
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
@@ -30,7 +49,7 @@ _TOKEN_TTL = 90 * 24 * 3600  # 90 days
 
 
 class BearerTokenError(Exception):
-    """No valid Bearer token. Run `letsfg auth` to authenticate via Twitter/X."""
+    """No valid Bearer token. Run `letsfg auth` to add a payment method."""
     pass
 
 
@@ -78,7 +97,7 @@ def get_bearer_token() -> str:
 
     raise BearerTokenError(
         "No valid LetsFG Bearer token.\n"
-        "  Run:  letsfg auth\n"
+        "  Run:  letsfg auth        (adds a payment method — nothing is charged)\n"
         "  Or:   export LETSFG_BEARER_TOKEN=<token>"
     )
 
@@ -92,7 +111,9 @@ def save_token(token: str, expires_at: float | None = None) -> None:
     _save_config(cfg)
 
 
-def _post_json(path: str, payload: dict, timeout: int = 30) -> dict:
+def _post_json(path: str, payload: dict, timeout: int = 30) -> tuple[int, dict]:
+    """POST and return (status, body). A 402 is an expected answer here, not an
+    error, so HTTPError is unwrapped rather than raised."""
     body = json.dumps(payload).encode()
     req = Request(
         f"{_BASE_URL}{path}",
@@ -100,53 +121,127 @@ def _post_json(path: str, payload: dict, timeout: int = 30) -> dict:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read())
-
-
-def twitter_auth() -> str:
-    """
-    Interactive auth flow — call this once to get a 90-day Bearer token.
-
-    Steps:
-      1. Calls POST /api/agent-access/request to get a challenge.
-      2. Prints the exact tweet to post.
-      3. Waits for you to post it, then calls POST /api/agent-access/verify.
-      4. Saves the token to ~/.letsfg/config.json and returns it.
-    """
-    print("\n  Connecting to LetsFG...")
-    data = _post_json("/api/agent-access/request", {})
-    challenge_code = data["challenge_code"]
-    tweet_text = data.get("tweet_text") or f"@letsfg {challenge_code}"
-
-    print(f"\n  Step 1 — post this tweet from your Twitter/X account:\n")
-    print(f"     {tweet_text}\n")
-    print(f"  Step 2 — press Enter once it's live.")
-    input()
-
-    print("  Verifying... ", end="", flush=True)
     try:
-        result = _post_json("/api/agent-access/verify", {"challenge_code": challenge_code})
+        with urlopen(req, timeout=timeout) as resp:
+            return resp.status, json.loads(resp.read())
     except HTTPError as e:
-        body = e.read().decode(errors="replace")
+        raw = e.read().decode(errors="replace")
+        try:
+            return e.code, json.loads(raw)
+        except Exception:
+            return e.code, {"error": raw[:400]}
+
+
+def _parse_expiry(raw_exp) -> float:
+    if isinstance(raw_exp, (int, float)):
+        return float(raw_exp)
+    if isinstance(raw_exp, str):
+        from datetime import datetime
+        try:
+            return datetime.fromisoformat(raw_exp.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            pass
+    return time.time() + _TOKEN_TTL
+
+
+def request_enrolment() -> dict:
+    """Start enrolment. Returns the 402 body with setup_url / setup_session_id."""
+    status, data = _post_json("/api/agent-access/request", {})
+    if status not in (200, 402):
         raise BearerTokenError(
-            f"Verification failed (HTTP {e.code}). "
-            "Make sure you posted the exact tweet above.\n"
-            f"Server: {body[:200]}"
+            f"Could not start authentication (HTTP {status}): {data.get('error', '')}"
+        )
+    return data
+
+
+def verify_payment_method(
+    *,
+    setup_session_id: str | None = None,
+    payment_method_id: str | None = None,
+    card_token: str | None = None,
+) -> str:
+    """
+    Exchange a payment method for a Bearer token. Saves and returns the token.
+
+    Pass exactly one of setup_session_id / payment_method_id / card_token.
+    """
+    payload: dict[str, str] = {}
+    if setup_session_id:
+        payload["setup_session_id"] = setup_session_id
+    elif payment_method_id:
+        payload["payment_method_id"] = payment_method_id
+    elif card_token:
+        payload["card_token"] = card_token
+    else:
+        raise BearerTokenError(
+            "Provide one of setup_session_id, payment_method_id, or card_token."
+        )
+
+    status, result = _post_json("/api/agent-access/verify", payload)
+    if status != 200 or "token" not in result:
+        raise BearerTokenError(
+            f"Verification failed (HTTP {status}). "
+            f"{result.get('hint') or result.get('error') or ''}".strip()
         )
 
     token = result["token"]
-    raw_exp = result.get("expires_at")
-    if isinstance(raw_exp, (int, float)):
-        expires_at = float(raw_exp)
-    elif isinstance(raw_exp, str):
-        from datetime import datetime, timezone
-        expires_at = datetime.fromisoformat(raw_exp.replace("Z", "+00:00")).timestamp()
-    else:
-        expires_at = time.time() + _TOKEN_TTL
-
+    expires_at = _parse_expiry(result.get("expires_at"))
     save_token(token, expires_at)
-    from datetime import datetime
-    exp_str = datetime.fromtimestamp(expires_at).strftime("%Y-%m-%d")
-    print(f"done. Token valid until {exp_str}.")
     return token
+
+
+def payment_auth(open_browser: bool = True) -> str:
+    """
+    Interactive auth — call once to get a 90-day Bearer token.
+
+    Opens Stripe's hosted card page, waits for you to finish, then verifies.
+    Nothing is charged.
+    """
+    print("\n  Connecting to LetsFG...")
+    data = request_enrolment()
+
+    setup_url = data.get("setup_url")
+    session_id = data.get("setup_session_id")
+    if not setup_url or not session_id:
+        raise BearerTokenError(
+            "Server did not return a setup URL. Check https://letsfg.co/for-agents"
+        )
+
+    print("\n  LetsFG needs a payment method on file before it can search or book.")
+    print("  Nothing is charged now — this is a zero-amount card setup.\n")
+    print(f"  Step 1 — add a card here:\n")
+    print(f"     {setup_url}\n")
+    if open_browser:
+        try:
+            webbrowser.open(setup_url)
+        except Exception:
+            pass
+    print("  Step 2 — press Enter once you've finished.")
+    input()
+
+    print("  Verifying... ", end="", flush=True)
+    token = verify_payment_method(setup_session_id=session_id)
+
+    from datetime import datetime
+    cfg_exp = _load_config().get("pfs_auth", {}).get("expires_at", time.time() + _TOKEN_TTL)
+    print(f"done. Token valid until {datetime.fromtimestamp(cfg_exp).strftime('%Y-%m-%d')}.")
+    return token
+
+
+def twitter_auth() -> str:
+    """Deprecated alias — Twitter/X auth was retired 2026-07-29.
+
+    Kept so existing scripts calling it keep working; it now runs the payment
+    flow instead of asking for a tweet. Note the previous implementation had
+    been broken for some time regardless: it posted {"challenge_code": ...} to
+    /api/agent-access/verify, which has always required {"tweet_url",
+    "challenge_signed"} and so always answered 400.
+    """
+    import warnings
+    warnings.warn(
+        "twitter_auth() is deprecated: LetsFG retired Twitter/X auth on 2026-07-29. "
+        "Use payment_auth() — nothing is charged.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return payment_auth()

--- a/sdk/python/letsfg/local.py
+++ b/sdk/python/letsfg/local.py
@@ -1,13 +1,15 @@
 """
-Cloud-backed flight search for LetsFG.
+Cloud-backed flight search and booking for LetsFG.
 
 Connectors run server-side at letsfg.co — same response schema, results
-in seconds. Authenticate once via Twitter/X (`letsfg auth`) for a free
+in seconds. Authenticate once with `letsfg auth`, which puts a payment method
+on file via a zero-amount Stripe setup (nothing is charged) and returns a
 90-day Bearer token.
 
 API flow:
     POST /api/search         → { search_id }
     GET  /api/results/<id>   → { status, offers[], total_results }  (poll every 10s)
+    POST /api/agent-book     → { ok, booked, order_id | booking_url }
 """
 
 from __future__ import annotations
@@ -44,7 +46,7 @@ async def search_local(
     """
     Search flights via the LetsFG cloud API.
 
-    Requires a Bearer token — run `letsfg auth` once to authenticate via Twitter/X.
+    Requires a Bearer token — run `letsfg auth` once. Free and unlimited.
     Returns { offers: [...], total_results: N, search_id: "..." }.
     """
     token = get_bearer_token()
@@ -112,6 +114,66 @@ async def search_local(
 
     print()
     return {"offers": [], "total_results": 0, "search_id": search_id}
+
+
+async def book_offer(
+    search_id: str,
+    offer_id: str,
+    passenger: dict,
+    contact_email: str,
+    *,
+    offer_ref: str | None = None,
+) -> dict:
+    """
+    Book an offer from a PFS search.
+
+    Requires a Bearer token (`letsfg auth`). Use REAL passenger details — names
+    must match the traveller's passport or government ID, and the airline sends
+    e-tickets to contact_email.
+
+    Returns either:
+        { "ok": True,  "booked": True,  "order_id": "...", "charged": 0 }
+      or, when the booking genuinely could not be completed:
+        { "ok": False, "booked": False, "error": "booking_unavailable",
+          "booking_url": "https://...", "charged": 0 }
+
+    A "booking_unavailable" result is a normal outcome, not a transient error.
+    Retrying will not book it — hand the user `booking_url`, which goes straight
+    to that exact offer. Nothing is charged in either case.
+    """
+    token = get_bearer_token()
+
+    payload: dict = {
+        "search_id": search_id,
+        "offer_id": offer_id,
+        "passenger": passenger,
+        "contact_email": contact_email,
+    }
+    if offer_ref:
+        payload["offer_ref"] = offer_ref
+
+    req = Request(
+        f"{_BASE_URL}/api/agent-book",
+        data=json.dumps(payload).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read())
+    except HTTPError as e:
+        if e.code == 401:
+            raise BearerTokenError(
+                "Bearer token expired or revoked. Run `letsfg auth` to re-authenticate."
+            )
+        raw = e.read().decode(errors="replace")
+        try:
+            return json.loads(raw)
+        except Exception:
+            return {"ok": False, "booked": False, "error": raw[:400]}
 
 
 async def _resolve_location_local(query: str) -> list[dict]:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "letsfg"
-version = "2026.5.80"
+version = "2026.5.81"
 description = "Flight search & booking for AI agents. Server-side engine covers hundreds of airlines. Free search via Bearer token or prepaid Developer API."
 readme = "README.md"
 license = {text = "MIT"}

--- a/skills/flight-search/SKILL.md
+++ b/skills/flight-search/SKILL.md
@@ -15,6 +15,23 @@ metadata:
 
 # Flight Search
 
+> **Correction (2026-07-29):** earlier revisions of this page described an MPP
+> (Machine Payments Protocol) `402` challenge letting agents pay in USDC.e on
+> Tempo with no card. That is **not enabled in production** — the server-side
+> support exists but is unconfigured, so no MPP challenge is ever issued. Do not
+> build against it.
+
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Agent-native flight search and booking via the LetsFG cloud engine. Hundreds of airlines, zero markup,
 $20–50 cheaper than travel websites.
 

--- a/skills/flight-search/references/api-reference.md
+++ b/skills/flight-search/references/api-reference.md
@@ -1,5 +1,22 @@
 # LetsFG API Reference
 
+> **Correction (2026-07-29):** earlier revisions of this page described an MPP
+> (Machine Payments Protocol) `402` challenge letting agents pay in USDC.e on
+> Tempo with no card. That is **not enabled in production** — the server-side
+> support exists but is unconfigured, so no MPP challenge is ever issued. Do not
+> build against it.
+
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Full endpoint details for the LetsFG flight search and booking API.
 
 **Base URL:** `https://letsfg.co/developers/api/v1`

--- a/skills/flight-search/references/mcp-setup.md
+++ b/skills/flight-search/references/mcp-setup.md
@@ -1,5 +1,16 @@
 # LetsFG MCP Server Setup
 
+> ### ⚠️ Agents: do not create a Developer API account
+>
+> Do **NOT** call `/developers/api/v1/agents/register` or
+> `/developers/api/v1/agents/setup-payment`, and do **NOT** run
+> `letsfg register` or `letsfg setup-payment`. Those belong to a separate,
+> paid, prepaid-balance product for high-volume commercial integrations and
+> create a billing account you almost certainly do not want.
+>
+> To search and book flights, run `letsfg auth` — a zero-amount card setup
+> (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
+
 Configure the LetsFG MCP server for your AI coding agent.
 
 ## Get an API Key First


### PR DESCRIPTION
## Why

Agents read `AGENTS.md` / `SKILL.md` / `docs/**` and were calling
`/developers/api/v1/agents/register` and `letsfg setup-payment`, quietly creating
prepaid billing accounts nobody wanted — because our own docs presented that as
the default path. It was not.

The live backend already changed (payment-token auth is deployed and verified on
letsfg.co). **This PR is what actually reaches installed clients.** Until the
packages are republished, agents keep following the old path.

## What changed

- Prominent "do not create a Developer API account" banner on all 22 agent-facing
  docs, SKILL manifests and quickstarts.
- Twitter/X challenge auth replaced throughout with payment-token auth: a
  zero-amount Stripe setup that charges nothing.
- Three enrolment lanes documented, including the **headless** one (agent confirms
  a SetupIntent itself against api.stripe.com with the publishable key — no
  browser, no human) and the MPP wallet lane ($0.01 verification, card-free).
- `POST /api/agent-book` documented, including that
  `{"booked": false, "booking_url": ...}` is a normal outcome that must not be
  retried.
- CLI: `letsfg auth` now runs the payment flow and accepts `--card-token` for
  headless agents. `register` / `setup-payment` print a loud notice and are
  relabelled Developer-API-only.
- MCP: new `authenticate` tool; `setup_payment` refuses unless `LETSFG_API_KEY` is
  explicitly set; `book_flight` routes Bearer-token callers to `/api/agent-book`
  and now **refuses** multi-passenger input instead of silently booking only the
  first passenger. Poll requests now carry the Authorization header.

## Corrections to claims that were not true

- The documented MPP/USDC.e "no card needed" unlock path was **not enabled in
  production** at the time (server support existed but was unconfigured, so no 402
  challenge was ever issued). Flagged wherever it appeared rather than left
  standing. MPP is now live, but as a $0.01 verification lane, which the docs state.
- The Python SDK's `twitter_auth()` posted `{"challenge_code"}` to a verify
  endpoint that has always required `{"tweet_url", "challenge_signed"}` — it could
  never have succeeded. Noted where it is now deprecated.

## Not included

Version bumps and the npm/PyPI publish. Those are the follow-up that actually
reaches installed agents.