### PR TITLE
release(npm): letsfg + letsfg-mcp 2026.5.58

### DIFF
--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "letsfg",
-  "version": "2026.5.54",
+  "version": "2026.5.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "letsfg",
-      "version": "2026.5.54",
+      "version": "2026.5.58",
       "license": "MIT",
       "bin": {
         "letsfg": "dist/cli.js"

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "letsfg",
-  "version": "2026.5.57",
+  "version": "2026.5.58",
   "description": "Flight search & booking for AI agents. Server-side engine covers hundreds of airlines. Free search via Bearer token or prepaid Developer API. Includes open-source ranking engine.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/mcp/package-lock.json
+++ b/sdk/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "letsfg-mcp",
-  "version": "2026.5.55",
+  "version": "2026.5.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "letsfg-mcp",
-      "version": "2026.5.55",
+      "version": "2026.5.58",
       "license": "MIT",
       "bin": {
         "letsfg-mcp": "dist/index.js"

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "letsfg-mcp",
-  "version": "2026.5.57",
+  "version": "2026.5.58",
   "mcpName": "io.github.LetsFG/letsfg",
   "description": "LetsFG MCP Server — server-side engine covers hundreds of airlines. Flight search for Claude, Cursor, Windsurf, and any MCP agent. Free search via Bearer token or prepaid Developer API.",
   "main": "dist/index.js",


### PR DESCRIPTION
Records the version numbers for the two npm packages already published from this code.

Both verified by packing `letsfg-mcp` back down from the registry and confirming the `authenticate` tool, the `/api/agent-book` route, the multi-passenger refusal, and the do-not-create-a-Developer-API-account guidance are all present.

- https://www.npmjs.com/package/letsfg/v/2026.5.58
- https://www.npmjs.com/package/letsfg-mcp/v/2026.5.58
- https://pypi.org/project/letsfg/2026.5.81/ (published earlier)