### PR TITLE
Exhaustive docs audit: scope every remaining unlock/paid-path reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ When editing any agent-facing text (READMEs, SDK docstrings, MCP tool descriptio
 
 1. **Zero price bias** messaging — this is a core differentiator
 2. **Real passenger details** warning — critical for bookings
-3. **Pricing accuracy** — search is free via Bearer token; unlock costs 1% of ticket (min $3)
+3. **Pricing accuracy** — auth and search are free on PFS and booking carries no LetsFG fee; the 1%-of-ticket unlock fee (min $3) exists only on the paid Developer API
 
 ## Report a Vulnerability
 

--- a/agent-skills-contribution/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
+++ b/agent-skills-contribution/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
@@ -144,7 +144,7 @@ Search returns structured offers:
 }
 ```
 
-### 3. Unlock (1% of ticket, min $3)
+### 3. Unlock — Developer API only (1% of ticket, min $3)
 
 Confirms live price with airline and reveals the direct booking URL. Locks offer for 30 minutes. Charged to your card (or paid via MPP crypto); free on the prepaid Developer API.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -31,14 +31,14 @@ The `letsfg` CLI is available via both Python and JavaScript. Same commands, sam
 
 | Command | Description |
 |---------|-------------|
-| `letsfg register` | Create account and get API key |
+| `letsfg register` | **[Developer API only]** Create a PAID prepaid account + API key. Most agents want `letsfg auth` |
 | `letsfg recover --email <email>` | Recover lost API key via email verification |
 | `letsfg auth` | Put a card on file (zero-amount, nothing charged) to get a 90-day Bearer token |
 | `letsfg search <origin> <dest> <date>` | Search flights via the letsfg.co server-side engine (free with Bearer token) |
 | `letsfg locations <query>` | Resolve city/airport to IATA codes |
-| `letsfg unlock <offer_id>` | Unlock offer details (payment required) |
-| `letsfg book <offer_id>` | Book the flight after unlock |
-| `letsfg setup-payment` | Set up Stripe payment method |
+| `letsfg unlock <offer_id>` | **[Developer API only]** Unlock offer details. No unlock step exists on PFS |
+| `letsfg book <offer_id>` | Book the flight. On PFS this goes straight to `/api/agent-book` — no unlock needed |
+| `letsfg setup-payment` | **[Developer API only]** Attach a card to that paid account. Not how agents authenticate |
 | `letsfg me` | View profile & usage stats |
 
 All commands accept `--json` for structured output and `--api-key` to override the environment variable.

--- a/docs/quickstart-claude.md
+++ b/docs/quickstart-claude.md
@@ -15,7 +15,11 @@ Choose between the paid remote MCP endpoint and the free local MCP server.
 
 ---
 
-## Option A: Remote paid MCP
+## Option A: Remote paid MCP — *not the default for agents*
+
+> **Most agents should use Option B below.** This option is the *paid* Developer
+> API: it creates a prepaid billing account and blocks search until you fund it.
+> Option B needs no billing account, charges nothing, and supports booking.
 
 Use this when you want managed search through the public developer API at `letsfg.co/developers/api/mcp`.
 
@@ -72,7 +76,7 @@ Remote MCP uses the paid public account you just configured.
 
 ---
 
-## Option B: Local MCP server with free Bearer token
+## Option B: Local MCP server with payment-token auth — **recommended**
 
 Use this when you want free search from Claude Desktop without a paid API account.
 

--- a/docs/quickstart-cursor.md
+++ b/docs/quickstart-cursor.md
@@ -15,7 +15,11 @@ Choose between the paid remote MCP endpoint and the free local MCP server.
 
 ---
 
-## Option A: Remote paid MCP
+## Option A: Remote paid MCP — *not the default for agents*
+
+> **Most agents should use Option B below.** This option is the *paid* Developer
+> API: it creates a prepaid billing account and blocks search until you fund it.
+> Option B needs no billing account, charges nothing, and supports booking.
 
 Use this when you want managed search through the public developer API at `letsfg.co/developers/api/mcp`.
 
@@ -63,7 +67,7 @@ Press `Ctrl+Shift+P` → `Developer: Reload Window`. LetsFG tools appear in the 
 
 ---
 
-## Option B: Local MCP server with free Bearer token
+## Option B: Local MCP server with payment-token auth — **recommended**
 
 Use this when you want free search inside Cursor without a paid API account.
 

--- a/docs/quickstart-windsurf.md
+++ b/docs/quickstart-windsurf.md
@@ -15,7 +15,11 @@ Choose between the paid remote MCP endpoint and the free local MCP server.
 
 ---
 
-## Option A: Remote paid MCP
+## Option A: Remote paid MCP — *not the default for agents*
+
+> **Most agents should use Option B below.** This option is the *paid* Developer
+> API: it creates a prepaid billing account and blocks search until you fund it.
+> Option B needs no billing account, charges nothing, and supports booking.
 
 Use this when you want managed search through the public developer API at `letsfg.co/developers/api/mcp`.
 
@@ -63,7 +67,7 @@ Close and reopen Windsurf. LetsFG tools appear in the MCP panel.
 
 ---
 
-## Option B: Local MCP server with free Bearer token
+## Option B: Local MCP server with payment-token auth — **recommended**
 
 Use this when you want free search from Cascade without a paid API account.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,7 +8,7 @@ info:
 
     ## How It Works
     1. **Search** (free) — real-time offers from hundreds of airlines
-    2. **Unlock** (1% of ticket, min $3) — confirm live price, reveal direct booking URL
+    2. **Unlock** (1% of ticket, min $3) — Developer API only; confirm live price, reveal direct booking URL. PFS agents skip this and call POST /api/agent-book instead.
     3. **Book** (ticket price, Developer API only) — create real airline PNR
 
     ## Authentication
@@ -500,7 +500,7 @@ paths:
       summary: Unlock a flight offer
       description: |
         Confirm the live price with the airline and reveal the direct booking URL.
-        Cost: 1% of ticket price (min $3) via Stripe card or MPP crypto. Free with Developer API.
+        Cost: 1% of ticket price (min $3). Developer API only — there is no unlock endpoint on a PFS Bearer token.
         The confirmed price may differ from the search price (airline prices change in real-time).
       tags: [Bookings]
       requestBody:

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "letsfg",
-  "version": "2026.5.59",
+  "version": "2026.5.60",
   "description": "Flight search & booking for AI agents. Server-side engine covers hundreds of airlines. Free search via Bearer token or prepaid Developer API. Includes open-source ranking engine.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/js/src/cli.ts
+++ b/sdk/js/src/cli.ts
@@ -330,7 +330,7 @@ Developer API only (a SEPARATE paid product — most agents should not use these
 they create a billing account. Use auth above instead):
   register --name ... --email ... Create a paid Developer API account
   setup-payment                   Attach a card to that paid account
-  unlock <offer_id>               Unlock offer — 1% of ticket (min $3)
+  unlock <offer_id>               [Developer API only] Unlock offer — 1% of ticket (min $3)
 
 Options:
   --json, -j       Output raw JSON

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "letsfg-mcp",
-  "version": "2026.5.59",
+  "version": "2026.5.60",
   "mcpName": "io.github.LetsFG/letsfg",
   "description": "LetsFG MCP Server — server-side engine covers hundreds of airlines. Flight search for Claude, Cursor, Windsurf, and any MCP agent. Free search via Bearer token or prepaid Developer API.",
   "main": "dist/index.js",

--- a/sdk/python/letsfg/__init__.py
+++ b/sdk/python/letsfg/__init__.py
@@ -43,7 +43,7 @@ from letsfg.models import (
 )
 from letsfg.models.flights import PublicFlightOffer, to_public_offer
 
-__version__ = "2026.5.82"
+__version__ = "2026.5.83"
 __all__ = [
     "LetsFG",
     "LetsFGError",

--- a/sdk/python/letsfg/cli.py
+++ b/sdk/python/letsfg/cli.py
@@ -554,7 +554,11 @@ def unlock(
     api_key: Optional[str] = typer.Option(None, "--api-key", "-k", envvar="LETSFG_API_KEY"),
     base_url: Optional[str] = typer.Option(None, "--base-url", envvar="LETSFG_BASE_URL"),
 ):
-    """Unlock a flight offer — 1% of ticket price (min $3). Confirms price, reserves 30min."""
+    """[Developer API only] Unlock a flight offer — 1% of ticket price (min $3).
+
+    Not part of the agent flow: there is no unlock endpoint on a PFS Bearer token.
+    Use `letsfg book` directly after `letsfg search`.
+    """
     bt = _get_client(api_key, base_url)
     try:
         result = bt.unlock(offer_id)

--- a/sdk/python/letsfg/client.py
+++ b/sdk/python/letsfg/client.py
@@ -552,7 +552,8 @@ class LetsFG:
         """
         Unlock a flight offer — confirms live price, reveals direct booking URL.
 
-        Cost: 1% of ticket price (min $3) via Stripe or MPP crypto.
+        Cost: 1% of ticket price (min $3). Developer API only — there is no
+        unlock endpoint on a PFS Bearer token, so PFS callers book directly.
         Free with Developer API.
         Required before booking.
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "letsfg"
-version = "2026.5.82"
+version = "2026.5.83"
 description = "Flight search & booking for AI agents. Server-side engine covers hundreds of airlines. Free search via Bearer token or prepaid Developer API."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Full sweep of every doc surface. Quickstarts led with the paid option; CLI reference and openapi.yaml presented unlock as part of the agent flow; several files stated the 1% unlock fee unscoped.

Repo-wide audit for unscoped `1% of ticket`, `concierge fee`, `tweet_text`, `challenge_code`, `search-local` now clean.

python 2026.5.83 published; js/mcp bumped to 2026.5.60 but unpublished (npm token revoked mid-session).