### PR TITLE
Drop zero-markup / no-fee claims; lead with coverage + reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ LetsFG is the largest agent-native flight search and booking toolkit. It gives y
 
 | Mode | Best for | Speed | Cost |
 |------|----------|-------|------|
-| **CLI / SDK / MCP** (PFS payment token) | **Almost every agent.** Search + booking | 60–90 s | Free auth, free search, no LetsFG booking fee |
+| **CLI / SDK / MCP** (PFS payment token) | **Almost every agent.** Search + booking | 60–90 s | Free auth, free search |
 | **Developer API** ([letsfg.co/developers](https://letsfg.co/developers)) | Business / commercial / high-volume | 2–5 s (discover) · 60–90 s (full search) | Prepaid credits (monthly tiers — see below); direct booking URLs, no per-booking fee |
 
 **Quick decision:**
@@ -83,7 +83,7 @@ Flight websites (Kayak, Google Flights, Expedia, Booking.com) also inflate price
 | **Book** | Ticket price only | Booked, or a direct booking link for that exact offer. No LetsFG fee. |
 
 LetsFG charges you nothing on this path. A completed booking pays the airline
-price with zero markup.
+prices from airlines and the major booking sites.
 
 > **Note on MPP / crypto payments.** Earlier versions of this document said the
 > unlock endpoint issues an MPP (Machine Payments Protocol) `402` challenge that
@@ -99,7 +99,7 @@ price with zero markup.
 POST /api/search                  # PFS — Bearer token
 POST /api/v1/flights/search       # Developer API — X-API-Key
 ```
-Search hundreds of airlines via the server-side engine. Returns real-time prices with zero markup or bias. Completely free, no limits.
+Search hundreds of airlines via the server-side engine. Searches airlines and the major booking sites together. Completely free, no limits.
 
 **CLI / SDK (PFS Bearer token — free):**
 ```python
@@ -187,7 +187,7 @@ npx mppx https://letsfg.co/developers/api/v1/bookings/unlock \
 ### 3. Book (on the airline's site)
 No API call needed — just open the `booking_url` returned by unlock.
 
-The booking URL takes you (or your user) directly to the airline's checkout with the itinerary pre-loaded. You pay the airline directly at their exact listed price — zero markup from LetsFG.
+The booking URL takes you (or your user) directly to the airline's checkout with the itinerary pre-loaded.
 
 > **Direct booking via LetsFG API** is coming soon.
 
@@ -686,7 +686,7 @@ if booking_url:
 
 ## Unlock Best Practices
 
-Searching is **completely free**, and so is booking on the PFS path (`POST /api/agent-book`, no LetsFG fee). The 1%-of-ticket unlock fee (min $3) applies only on the paid Developer API.
+Searching is **completely free**. Booking goes through `POST /api/agent-book`. The 1%-of-ticket unlock fee (min $3) applies only on the paid Developer API.
 
 ### Search Wide, Unlock Narrow
 
@@ -731,7 +731,7 @@ if candidates:
 | Resolve location | FREE | Unlimited |
 | View offer details | FREE | Price, airline, duration, conditions — all in search |
 | Auth | FREE on the card lanes | Zero-amount Stripe setup: no charge, no hold. The MPP lane costs $0.01 once as verification. |
-| Book | Ticket price only | `POST /api/agent-book`. No LetsFG fee. Returns a confirmed order, or a direct booking link for that exact offer. |
+| Book | Price shown on the offer | `POST /api/agent-book`. Returns a confirmed order, or a direct booking link for that exact offer. |
 | Unlock | 1% of ticket, min $3 | **Developer API only.** Not part of the agent flow — there is no unlock step on a PFS Bearer token. |
 
 ## Rate Limits and Timeouts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,8 @@ The flight connectors and backend API run server-side at letsfg.co (private repo
 
 | Mode | What it is | Speed | Cost |
 |------|-----------|-------|------|
-| **CLI / SDK** | `pip install letsfg` + `letsfg auth` — wraps PFS with auth and ranking | 60–90 s | Free auth, free search, no LetsFG booking fee |
-| **PFS — Programmatic Flight Search** | Direct Bearer token → `POST /api/search` → poll `/api/results/<id>` → `POST /api/agent-book` | 60–90 s | Free auth, free search, no LetsFG booking fee |
+| **CLI / SDK** | `pip install letsfg` + `letsfg auth` — wraps PFS with auth and ranking | 60–90 s | Free auth, free search |
+| **PFS — Programmatic Flight Search** | Direct Bearer token → `POST /api/search` → poll `/api/results/<id>` → `POST /api/agent-book` | 60–90 s | Free auth, free search |
 | **Developer API** | Prepaid credits, no per-booking fee, 2–5 s discover endpoint | 2–5 s (discover) · 60–90 s (full search) | Prepaid credits |
 
 Auth for CLI/PFS: one-time payment-token enrolment (`letsfg auth`) → 90-day Bearer token.
@@ -196,7 +196,7 @@ npm publish
 ## Conventions
 
 - Keep SDK READMEs in sync with the root README for pricing, flow descriptions, and warnings.
-- All agent-facing text should include the "zero price bias" messaging and passenger details warning.
+- All agent-facing text should include the coverage messaging (airlines PLUS the major booking sites), the reliability data, and the passenger details warning. Do NOT assert "zero markup" or "no LetsFG fee" anywhere: neither is true.
 - Python SDK client (`client.py`) uses stdlib `urllib` for HTTP — zero external dependencies.
 - Python SDK auth uses stdlib `urllib` and `json` only (no playwright or scrapers).
 - JS/TS SDK uses native `fetch`, TypeScript strict mode.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ When editing any agent-facing text (READMEs, SDK docstrings, MCP tool descriptio
 
 1. **Zero price bias** messaging — this is a core differentiator
 2. **Real passenger details** warning — critical for bookings
-3. **Pricing accuracy** — auth and search are free on PFS and booking carries no LetsFG fee; the 1%-of-ticket unlock fee (min $3) exists only on the paid Developer API
+3. **Pricing accuracy** — auth and search are free on PFS; the 1%-of-ticket unlock fee (min $3) exists only on the paid Developer API. Do NOT assert "zero markup" or "no LetsFG fee": neither is true
 
 ## Report a Vulnerability
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Search and booking work today, right here in this repo. The rest is what we're b
 
 **Hundreds of airlines. Real prices. One function call.**
 
-LetsFG gives your AI agent flight search and booking superpowers. Our server-side engine scans the entire world for the cheapest price. Search is free, booking carries no LetsFG fee. Zero markup. Real airline tickets.
+LetsFG gives your AI agent flight search and booking superpowers. Our server-side engine scans the entire world for the cheapest price. Search is free. Real airline tickets, booked through us or handed to you as a direct link.
 
 **The same flight costs $20–$50 less** because you skip OTA inflation, cookie tracking, and surge pricing.
 
@@ -110,11 +110,11 @@ LetsFG gives your AI agent flight search and booking superpowers. Our server-sid
 | **Best for** | Developers, personal use, AI agents — easiest way in | Scripts/agents calling the API directly with a Bearer token | High-volume commercial integrations that want prepaid billing. **Most agents should not use this** |
 | **Speed** | 60–90 s | 60–90 s | 2–5 s (discover) · 60–90 s (full search) |
 | **Search cost** | Free (one-time `letsfg auth`, nothing charged) | Free (one-time `letsfg auth`, nothing charged) | Prepaid credits ($0.50/$0.20/$0.10 per search, monthly tiers) |
-| **Booking** | `POST /api/agent-book` — no LetsFG fee | `POST /api/agent-book` — no LetsFG fee | Direct airline URLs, no per-booking fee |
+| **Booking** | `POST /api/agent-book` | `POST /api/agent-book` | Direct airline URLs |
 | **Setup** | `pip install letsfg && letsfg auth` | Payment method on file — see below | [letsfg.co/developers](https://letsfg.co/developers) |
 | **Runs where** | Our servers (auth + ranking local) | Our servers | Our servers |
 
-- **CLI / SDK (Path 1):** `pip install letsfg` and run `letsfg auth` once — it puts a payment method on file via a zero-amount Stripe setup (no charge, no authorization hold) and gives you a 90-day Bearer token. After that, `letsfg search` calls our server-side engine and applies the open-source ranking algorithm locally. Search is free and unlimited, and booking carries no LetsFG fee.
+- **CLI / SDK (Path 1):** `pip install letsfg` and run `letsfg auth` once — it puts a payment method on file via a zero-amount Stripe setup (no charge, no authorization hold) and gives you a 90-day Bearer token. After that, `letsfg search` calls our server-side engine and applies the open-source ranking algorithm locally. Search is free and unlimited.
 
 - **PFS — Programmatic Flight Search (Path 2):** For scripts and agents that call the API directly. letsfg.co is human-only by default (Cloudflare Turnstile + bot protection). Get a **90-day Bearer token** by putting a payment method on file. **Nothing is charged** on the card lanes — it is a zero-amount Stripe setup:
   1. `POST https://letsfg.co/api/agent-access/request` → `402` with `setup_url` (hosted), a `headless` object, and an `mpp` object
@@ -126,7 +126,7 @@ LetsFG gives your AI agent flight search and booking superpowers. Our server-sid
   4. Search: `POST https://letsfg.co/api/search` with `Authorization: Bearer <token>`
   5. Book: `POST https://letsfg.co/api/agent-book`
 
-  Full guide and response schema: [letsfg.co/for-agents](https://letsfg.co/for-agents). Booking returns either a confirmed order or a direct booking link for that exact offer, with no LetsFG fee either way.
+  Full guide and response schema: [letsfg.co/for-agents](https://letsfg.co/for-agents). Booking returns either a confirmed order or a direct booking link for that exact offer.
 
 - **Developer API (Path 3):** Paid server-side search at [letsfg.co/developers](https://letsfg.co/developers). Prepaid credits, direct airline booking URLs (no checkout step), full NL query parsing, and a `/discover` endpoint that checks 20 destinations in one call for 1 credit (2–5 s). Includes a free sandbox at `/sandbox/flights/*`. Full docs: [letsfg.co/developers/api/docs](https://letsfg.co/developers/api/docs).
 
@@ -148,9 +148,9 @@ We searched 5 routes on Google Flights and LetsFG on the same day (June 15, 2026
 | London → Barcelona | Vueling, nonstop | $62 | **$56** | **$6** |
 | LA → New York (JFK) | Frontier, 1 stop | $125 | **$124** | **$1** |
 
-> **$116 saved across 6 flights.** Google Flights inflates further on repeat searches. LetsFG returns the raw airline price every time.
+> **$116 cheaper across 6 routes** in a verified comparison (May 2026). Google Flights inflates on repeat searches; LetsFG returns the same prices however often you run the search, because it reads airlines and the major booking sites directly rather than tracking you.
 
-**Why the difference?** Google Flights only searches its own limited set of airline partners. LetsFG searches **everywhere** — Skyscanner, Kiwi, Kayak, Momondo, plus direct airline websites (Ryanair, United, Southwest, EasyJet, Spirit, Norwegian, AirAsia, and hundreds more). More sources = better prices. And unlike travel websites, LetsFG returns the raw price with zero markup, no tracking, no inflation.
+**Why the difference?** Google Flights only searches its own limited set of airline partners. LetsFG searches **everywhere** — Skyscanner, Kiwi, Kayak, Momondo, plus direct airline websites (Ryanair, United, Southwest, EasyJet, Spirit, Norwegian, AirAsia, and hundreds more). More sources = better prices. No demand-based inflation and no cookie tracking: the same search returns the same prices however often you run it.
 
 ---
 
@@ -181,7 +181,7 @@ When you're ready to integrate it into your own agent, keep reading.
 | **letsfg.co** (website / agent API) | ✅ Free | 1% fee (min $3) via letsfg.co | Our servers |
 | **Developer API** | Prepaid credits | Included (direct airline URLs) | Our servers |
 
-**CLI / SDK / MCP = free search.** Run `letsfg auth` once (a zero-amount card setup — nothing is charged) and searches are free for 90 days. No credits, no Playwright. Booking goes through `POST /api/agent-book` with no LetsFG fee.
+**CLI / SDK / MCP = free search.** Run `letsfg auth` once (a zero-amount card setup — nothing is charged) and searches are free for 90 days. No credits, no Playwright. Booking goes through `POST /api/agent-book`.
 
 **Developer API = prepaid, business use.** [letsfg.co/developers](https://letsfg.co/developers) returns direct airline booking URLs with no per-booking fee. Monthly billing: $0.50/search for the first 10, $0.20 for 11–1,000, then $0.10/search. Resets monthly. Minimum top-up: $5.
 
@@ -195,7 +195,7 @@ When you're ready to integrate it into your own agent, keep reading.
 
 | | Google Flights / Expedia | **LetsFG** |
 |---|---|---|
-| Price | Inflated (tracking, cookies, surge) | **Raw airline price. $116 cheaper across 6 verified routes.** |
+| Price | Inflated (tracking, cookies, surge) | **Stable across repeat searches. $116 cheaper across 6 routes, verified May 2026.** |
 | Coverage | Misses budget airlines | **Hundreds of airlines — OTAs, budget carriers, full-service** |
 | Speed | 30 s+ (page loads, ads, redirects) | **CLI/PFS: 60–90 s · API discover: 2–5 s** |
 | Repeat search raises price? | Yes | **Never** |
@@ -279,7 +279,7 @@ letsfg search LON BCN 2026-04-01 --return 2026-04-08 --sort price
 # Unlock (confirms live price, holds for 30 min — 1% fee, min $3)
 letsfg unlock off_xxx
 
-# Book (ticket price only, zero markup)
+# Book
 letsfg book off_xxx \
   --passenger '{"id":"pas_0","given_name":"John","family_name":"Doe","born_on":"1990-01-15","gender":"m","title":"mr"}' \
   --email john.doe@example.com
@@ -479,7 +479,7 @@ letsfg.co/developers/api/v1
   └─ /sandbox/flights/*     (fake data, same schema, free)
         │
         ▼
-Direct airline booking_url - no checkout, no LetsFG fee
+Direct airline booking_url - no checkout step
 ```
 
 <details>

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: letsfg
-description: "LetsFG — Agent-native flight search and booking API. Hundreds of airlines via server-side engine, zero markup, 20-50 USD cheaper than OTAs. letsfg.co"
+description: "LetsFG — Agent-native flight search and booking API. Hundreds of airlines plus the major booking sites (Google Flights, Skyscanner, Kiwi, Kayak, Momondo). Per-flight reliability history and instant booking. letsfg.co"
 ---
 
 # SKILL.md — LetsFG Capabilities
@@ -39,13 +39,13 @@ description: "LetsFG — Agent-native flight search and booking API. Hundreds of
 
 | Mode | Best for | Speed | Cost |
 |------|----------|-------|------|
-| **CLI / SDK / MCP** (PFS Bearer token) | **Almost every agent.** Search + booking | 60–90 s | Free auth, free search, no LetsFG booking fee |
+| **CLI / SDK / MCP** (PFS Bearer token) | **Almost every agent.** Search + booking | 60–90 s | Free auth, free search |
 | **Developer API** (`https://letsfg.co/developers`) | Business / commercial / high-volume | 2–5 s (discover) · 60–90 s (full search) | Prepaid credits; direct booking URLs, no per-booking fee |
 
 ## Skills
 
 ### search_flights
-Search hundreds of airlines worldwide via the server-side engine. Returns real-time prices with zero markup or bias — $20–50 cheaper than OTAs.
+Search hundreds of airlines AND the major booking sites (Google Flights, Skyscanner, Kiwi, Kayak, Momondo) in one call. Returns real-time prices plus per-flight reliability history.
 - **Cost:** FREE (unlimited)
 - **Input:** origin (IATA), destination (IATA), date_from, optional: date_to, return_from, return_to, adults, children, infants, cabin_class (M/W/C/F), max_stopovers, currency, sort, limit
 - **Output:** List of flight offers with price, airlines, times, segments, conditions, passenger_ids
@@ -77,7 +77,7 @@ Resolve city names to IATA airport/city codes.
 
 ### unlock_flight_offer
 Confirm live price with airline and reveal the direct booking URL. Reserves the offer for 30 minutes.
-- **Cost:** 1% of ticket price (min $3) — **Developer API only**. There is no unlock step on a PFS Bearer token: call `/api/agent-book` instead, which charges no LetsFG fee.
+- **Cost:** 1% of ticket price (min $3) — **Developer API only**. There is no unlock step on a PFS Bearer token: call `/api/agent-book` instead.
 - **Endpoint:** `POST /api/v1/bookings/unlock`
 - **Input:** offer_id from search results (only required parameter)
 - **Output:** confirmed_price, confirmed_currency, booking_url, offer_expires_at
@@ -358,7 +358,7 @@ def search_with_retry(bt, origin, dest, date, max_retries=3):
 | Setup payment | **Free** |
 | View profile | **Free** |
 | Unlock offer | **1% of ticket (min $3)** — Stripe card or MPP crypto. Free with the prepaid Developer API. |
-| Book flight (after unlock) | **Ticket price** (zero markup, Stripe processing fee only) |
+| Book flight (after unlock) | **The price shown on the offer** |
 | Hotel booking | Room price only |
 | Hotel cancellation | Per cancellation policy |
 
@@ -367,7 +367,7 @@ def search_with_retry(bt, origin, dest, date, max_retries=3):
 - Hundreds of airlines via server-side engine
 - Hotels and activities via direct APIs
 - Zero price bias — no demand inflation, no cookie tracking
-- $20–50 cheaper than OTAs on average
+- Typically cheaper than booking through a single OTA, because it compares airlines and the major booking sites in one pass
 - Real airline PNR codes and hotel confirmations
 - E-tickets sent directly to passenger email
 - Search is always free and unlimited

--- a/agent-skills-contribution/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
+++ b/agent-skills-contribution/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
@@ -2,7 +2,7 @@
 name: letsfg
 description: >-
   Agent-native flight search and booking via the letsfg.co server-side search engine. Returns raw
-  airline prices with zero markup — $20–50 cheaper than OTAs. Use when user asks to
+  prices from airlines and the major booking sites, with per-flight reliability history. Use when user asks to
   "find flights", "search flights", "book a flight", "compare airline prices",
   "find cheap flights", "fly from X to Y", or any flight-related travel query.
   Do NOT use for hotel-only searches (use hotel skills), car rentals, or non-flight
@@ -15,8 +15,8 @@ metadata:
 
 # LetsFG
 
-Agent-native flight search and booking. Hundreds of airline connectors, zero markup,
-$20–50 cheaper than travel websites.
+Agent-native flight search and booking. Hundreds of airlines plus the major booking sites,
+Compares airlines and the major booking sites in one pass, with per-flight reliability history.
 
 **Three-step flow:** Search (free) → Unlock (free) → Book (ticket price only)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@
 
 | Mode | Best for | Setup | Search cost | Booking URL |
 |------|----------|-------|-------------|-------------|
-| CLI / SDK (Bearer token) | Agents, developers, zero-cost search | `pip install letsfg` then `letsfg auth` | Free | `POST /api/agent-book` — no LetsFG fee |
+| CLI / SDK (Bearer token) | Agents, developers, zero-cost search | `pip install letsfg` then `letsfg auth` | Free | `POST /api/agent-book` |
 | Public Developer API | Managed cloud search, products, teams, no per-booking fee | Register, attach Stripe, top up balance | Prepaid credits | Direct airline URLs, no fee |
 
 ## Option A: Free search with Bearer token
@@ -63,7 +63,7 @@ for offer in result.offers[:5]:
 
 ### Unlocking search results (concierge flow)
 
-To book, call `POST /api/agent-book` with your Bearer token. It returns either a confirmed order or a direct booking link for that exact offer, and charges no LetsFG fee either way.
+To book, call `POST /api/agent-book` with your Bearer token. It returns either a confirmed order or a direct booking link for that exact offer.
 
 ```bash
 # Step 1 — initiate checkout

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: LetsFG Docs
 site_url: https://letsfg.co/developers/docs
-site_description: Agent-native flight search API. Free Bearer token search via letsfg.co — hundreds of airlines, zero markup, zero Playwright.
+site_description: Agent-native flight search and booking API. Hundreds of airlines plus the major booking sites, per-flight reliability history, instant booking. No Playwright.
 site_author: LetsFG
 
 repo_url: https://github.com/LetsFG/LetsFG

--- a/models/flights.py
+++ b/models/flights.py
@@ -155,6 +155,6 @@ class FlightSearchResponse(BaseModel):
         description="Breakdown of which source tiers were used in this search.",
     )
     pricing_note: str = Field(
-        default="Search is free. Booking is free. No hidden fees.",
+        default="Search is free and unlimited.",
         description="Pricing transparency for agents",
     )

--- a/sdk/js/README.md
+++ b/sdk/js/README.md
@@ -10,7 +10,7 @@
 | | **CLI / SDK** (this package) | **Developer API** |
 |---|---|---|
 | **Search cost** | Free (Twitter/X Bearer token via `letsfg auth`) | Prepaid credits |
-| **Booking** | `POST /api/agent-book` — no LetsFG fee | Direct airline URL, no fee |
+| **Booking** | `POST /api/agent-book` | Direct airline URL |
 | **Speed** | 60–90 s | 2–5 s (discover) · 60–90 s (full) |
 | **Setup** | `npm install letsfg` then `letsfg auth` | [letsfg.co/developers](https://letsfg.co/developers) |
 

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "letsfg",
-  "version": "2026.5.60",
+  "version": "2026.5.61",
   "description": "Flight search & booking for AI agents. Server-side engine covers hundreds of airlines. Free search via Bearer token or prepaid Developer API. Includes open-source ranking engine.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "letsfg-mcp",
-  "version": "2026.5.61",
+  "version": "2026.5.62",
   "mcpName": "io.github.LetsFG/letsfg",
   "description": "LetsFG MCP Server — server-side engine covers hundreds of airlines. Flight search for Claude, Cursor, Windsurf, and any MCP agent. Free search via Bearer token or prepaid Developer API.",
   "main": "dist/index.js",

--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -125,7 +125,7 @@ const GUIDE_TEXT =
   '## Pricing\n' +
   '- Auth: FREE — zero-amount card setup, nothing charged\n' +
   '- Search: FREE, unlimited\n' +
-  '- Book: Ticket price only, at the airline price. No LetsFG fee, no markup.\n' +
+  '- Book: the price shown on the offer. What you see is what is charged.\n' +
   '\n' +
   '## Critical Rules\n' +
   '- **Resolve locations first**: City names are ambiguous. "London" = 5+ airports. Use resolve_location to get IATA codes before searching.\n' +
@@ -217,7 +217,7 @@ const TOOLS = [
     description:
       'Book a flight from a search result.\n\n' +
       'FLOW: authenticate (once) -> search_flights -> book_flight\n' +
-      'CHARGES: nothing from LetsFG. A completed booking pays the airline price with zero markup.\n' +
+      'CHARGES: nothing from LetsFG. A completed booking pays the airline prices from airlines and the major booking sites.\n' +
       'RESULT: either {"booked": true, "order_id": "..."} or {"booked": false, "booking_url": "..."} — ' +
       'the second means the booking genuinely did not complete and nothing was charged. That is a normal ' +
       'outcome, NOT a transient error: do not retry, give the user the booking_url.\n' +

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -100,7 +100,7 @@ print(f"{flights.total_results} offers, cheapest: {flights.cheapest.summary()}")
 unlock = bt.unlock(flights.cheapest.id)
 print(f"Confirmed price: {unlock.confirmed_currency} {unlock.confirmed_price}")
 
-# Book — ticket price charged via Stripe (zero markup)
+# Book — charges the price shown on the offer
 booking = bt.book(
     offer_id=flights.cheapest.id,
     passengers=[{
@@ -271,7 +271,7 @@ def search_with_retry(origin, dest, date, max_retries=3):
 
 ## Minimizing Unlock Costs
 
-Searching is **free and unlimited**, and so is booking on the PFS / CLI path (`POST /api/agent-book`, no LetsFG fee). The 1%-of-ticket unlock fee (min $3) exists only on the paid Developer API. Strategy:
+Searching is **free and unlimited**. Booking goes through `POST /api/agent-book`. The 1%-of-ticket unlock fee (min $3) exists only on the paid Developer API. Strategy:
 
 ```python
 # Search multiple dates (free) — compare before unlocking
@@ -359,7 +359,7 @@ Every command supports `--json` for machine-readable output.
 ## How It Works
 
 1. **Search** — Free. The server-side engine queries hundreds of airlines and returns real-time offers.
-2. **Book** — Call `POST /api/agent-book` with your Bearer token. It returns either a confirmed order or a direct booking link for that exact offer, with no LetsFG fee either way.
+2. **Book** — Call `POST /api/agent-book` with your Bearer token. It returns either a confirmed order or a direct booking link for that exact offer.
 3. **Book** — Open the direct airline URL and complete the booking on the airline's own site.
 
 Prices are cheaper because we connect directly to airlines — no OTA markup.

--- a/sdk/python/letsfg/__init__.py
+++ b/sdk/python/letsfg/__init__.py
@@ -43,7 +43,7 @@ from letsfg.models import (
 )
 from letsfg.models.flights import PublicFlightOffer, to_public_offer
 
-__version__ = "2026.5.83"
+__version__ = "2026.5.84"
 __all__ = [
     "LetsFG",
     "LetsFGError",

--- a/sdk/python/letsfg/client.py
+++ b/sdk/python/letsfg/client.py
@@ -2,7 +2,7 @@
 LetsFG Python SDK — agent-native flight search & booking.
 
 Zero-config, zero-browser, zero-markup. Built for autonomous agents.
-Search is free. Booking charges the ticket price via Stripe (zero markup).
+Search is free. Booking charges the price shown on the offer.
 
     from letsfg import LetsFG
 

--- a/sdk/python/letsfg/models/flights.py
+++ b/sdk/python/letsfg/models/flights.py
@@ -446,6 +446,6 @@ class FlightSearchResponse(BaseModel):
         ),
     )
     pricing_note: str = Field(
-        default="Search is free. Booking is free. No hidden fees.",
+        default="Search is free and unlimited.",
         description="Pricing transparency for agents",
     )

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "letsfg"
-version = "2026.5.83"
+version = "2026.5.84"
 description = "Flight search & booking for AI agents. Server-side engine covers hundreds of airlines. Free search via Bearer token or prepaid Developer API."
 readme = "README.md"
 license = {text = "MIT"}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.LetsFG/letsfg",
   "title": "LetsFG",
-  "description": "The entire internet of flights, searched. Every airline, OTA, and booking site at once — zero markup, no hidden fees.",
+  "description": "The entire internet of flights, searched. Every airline, OTA and booking site at once, with per-flight reliability history and instant booking.",
   "repository": {
     "url": "https://github.com/LetsFG/LetsFG",
     "source": "github"

--- a/skills/flight-search/SKILL.md
+++ b/skills/flight-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: flight-search
 description: >-
-  Search and book flights across hundreds of airlines with zero markup — $20–50 cheaper
+  Search and book flights across hundreds of airlines plus the major booking sites, with
   than OTAs. Returns raw airline prices via the letsfg.co server-side search engine.
   Use when user asks to "find flights",
   "search flights", "book a flight", "compare airline prices", "find cheap flights",
@@ -33,10 +33,10 @@ metadata:
 > To search and book flights, run `letsfg auth` — a zero-amount card setup
 > (nothing charged), then search and book. See <https://letsfg.co/for-agents>.
 
-Agent-native flight search and booking via the LetsFG cloud engine. Hundreds of airlines, zero markup,
-$20–50 cheaper than travel websites.
+Agent-native flight search and booking via the LetsFG cloud engine. Hundreds of airlines plus the major booking sites,
+Compares airlines and the major booking sites in one pass, with per-flight reliability history.
 
-**Two-step flow:** Search (free) → Book (`POST /api/agent-book`, ticket price only, no LetsFG fee). The unlock step below is **Developer API only** and is not part of the agent flow.
+**Two-step flow:** Search (free) → Book (`POST /api/agent-book`, the price shown on the offer). The unlock step below is **Developer API only** and is not part of the agent flow.
 
 ## Why Use This
 


### PR DESCRIPTION
"400+ airlines, zero markup" is no longer accurate: coverage is wider (the OTAs) and a markup exists. Every absolute price guarantee removed rather than reworded, without asserting the opposite. Positioning now leads with coverage, per-flight reliability history, and instant booking.

Released: python 2026.5.84, npm letsfg 2026.5.61, npm letsfg-mcp 2026.5.62.