### PR TITLE
fix(js-sdk): set explicit User-Agent on LetsFG.register()

### DIFF
--- a/sdk/js/src/index.test.ts
+++ b/sdk/js/src/index.test.ts
@@ -44,6 +44,38 @@ describe('LetsFG class', () => {
   });
 });
 
+// ── register() sends an explicit User-Agent ─────────────────────────────────
+// Every other request in this file goes through requestWithHeaders(), which
+// sets User-Agent: LetsFG-js/0.1.0. register() builds its own bare fetch()
+// call and used to skip that header entirely -- Node's fetch silently fills
+// in "node" as a default, which happened not to trip Cloudflare's WAF, but
+// relying on that undocumented runtime default is the same fragile pattern
+// that broke the Python SDK's PFS auth flow the same week (missing UA ->
+// Cloudflare error 1010). Assert it explicitly instead of implicitly.
+describe('register()', () => {
+  it('sets an explicit User-Agent header', async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedHeaders: Record<string, string> | undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      capturedHeaders = init?.headers as Record<string, string>;
+      return {
+        ok: true,
+        json: async () => ({ agent_id: 'agt_test' }),
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      await LetsFG.register('test-agent', 'agent@example.com');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.ok(capturedHeaders, 'fetch was not called');
+    assert.ok(capturedHeaders!['User-Agent'], 'no User-Agent header was sent');
+    assert.notEqual(capturedHeaders!['User-Agent'], 'node');
+  });
+});
+
 // ── Input validation — auth guard ─────────────────────────────────────────
 
 describe('auth guard', () => {

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -478,7 +478,7 @@ export class LetsFG {
     const url = (baseUrl || DEFAULT_BASE_URL).replace(/\/$/, '');
     const resp = await fetch(`${url}/developers/api/v1/agents/register`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'User-Agent': 'LetsFG-js/0.1.0' },
       body: JSON.stringify({ agent_name: agentName, email, owner_name: ownerName, description }),
     });
 


### PR DESCRIPTION
## Summary
Follow-up to #178 (the Python SDK's PFS auth 403/1010 fix, #163/#177) — audited every `fetch()` call site in `sdk/js` and `sdk/mcp` for the same "missing explicit User-Agent" pattern.

- **`sdk/mcp`**: clean. All 4 `fetch()` call sites already set an explicit `User-Agent: letsfg-mcp/${VERSION}`.
- **`sdk/js`**: one gap. `LetsFG.register()` builds its own bare `fetch()` call and skips the header that `requestWithHeaders()` sets on every other request (`User-Agent: LetsFG-js/0.1.0`).

This is **not** the same bug as #163/#177 — the JS/TS SDK doesn't implement the PFS zero-amount auth flow (`/api/agent-access/request` / `/verify`) at all, so it can't hit that exact failure. It's currently non-triggering too: Node's `fetch` silently fills in `User-Agent: node` when none is set, and Cloudflare's rule specifically targets the `Python-urllib` signature — verified live that `curl -A node` gets through the Developer API register endpoint while `curl -A Python-urllib/3.13` gets blocked with error 1010.

But it's the same fragile pattern: relying on an unstated runtime default instead of an explicit header, on the one call site that doesn't go through the shared helper. Fixing for consistency and to not be one WAF rule change away from silently breaking.

## Verification
- New test in `index.test.ts` (`register()` → `sets an explicit User-Agent header`) mocks `fetch` and asserts a non-default UA is sent.
- Full suite: `npm test` → 23/23 passing.
- `npm run build` succeeds.