### PR TITLE
Add a real, verified hotel price comparison vs Booking.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,22 @@ We searched 5 routes on Google Flights and LetsFG on the same day (2026-08-05), 
 
 ---
 
+## Real hotel prices: LetsFG vs Booking.com
+
+Same hotel, same room type, same 2-night stay, same free-cancellation policy — checked on the same day (2026-08-05) for a 2026-09-16 check-in:
+
+| Hotel | Booking.com | LetsFG | You Save |
+|-------|------------|--------|----------|
+| Hotel Boss, Warsaw | 768 zł | **630 zł** | **138 zł** |
+| ibis Styles Paris Gare de l'Est | 2,475 zł | **1,959 zł** | **516 zł** |
+| Copthorne Tara Hotel, London Kensington | 1,415 zł | **1,294 zł** | **121 zł** |
+
+> **775 zł cheaper across 3 hotels** in a verified comparison (2026-08-05), matching each property's own free-cancellation rate against Booking.com's free-cancellation rate for the identical dates and room type.
+
+**Why the difference?** LetsFG sells at wholesale cost plus a flat 10% reservation fee — no markup for demand, no loyalty-program cross-subsidy. Only free-cancellation, pay-later rates are sold, so every price shown is one you can actually book.
+
+---
+
 ## Try it right now — no install needed
 
 **Human users:** Use [letsfg.co](https://letsfg.co) and search flights instantly in your browser:


### PR DESCRIPTION
## Summary
- Added a "Real hotel prices: LetsFG vs Booking.com" section, same style as the existing flights comparison.
- 3 hotels (Warsaw, Paris, London), same room type, same 2-night stay (2026-09-16 checkin), same free-cancellation policy on both sides, checked live today (2026-08-05).
- 775 zl cheaper across 3 hotels - matches how LetsFG actually prices hotels (wholesale cost + flat 10% reservation fee, confirmed against the live pricing config).

## Test plan
- [x] Real live LetsFG hotel prices pulled through the actual production search pipeline
- [x] Real live Booking.com prices for the identical hotel/room/dates/cancellation-policy, cross-checked on each property's own availability table (not just the search-results summary card)
- [x] No customer data or payment methods touched to get this data

Generated with Claude Code