### PR TITLE
Fix JS SDK book() to support the free PFS booking path

### DIFF
--- a/sdk/js/src/cli.ts
+++ b/sdk/js/src/cli.ts
@@ -17,6 +17,7 @@ import {
   offerSummary,
   type FlightSearchResult,
   type SearchOptions,
+  type BookingResult,
 } from './index.js';
 
 // ── Arg parsing (zero-dependency) ────────────────────────────────────────
@@ -178,7 +179,9 @@ async function cmdBook(args: string[]) {
 
   const passengers = passengerStrs.map(s => JSON.parse(s));
   const bt = new LetsFG({ apiKey, baseUrl });
-  const result = await bt.book(offerId, passengers, email, phone);
+  // This CLI only ever constructs LetsFG with an apiKey, never a bearerToken,
+  // so book() always takes the Developer API branch and returns BookingResult.
+  const result = await bt.book(offerId, passengers, email, phone) as BookingResult;
 
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -418,8 +418,17 @@ export class LetsFG {
   }
 
   /**
-   * Book a flight via Developer API — charges ticket price via Stripe, creates real PNR.
-   * Always provide idempotencyKey to prevent double-bookings on retry.
+   * Book a flight.
+   *
+   * PFS (Bearer token): POST /api/agent-book. Free — nothing charged beyond
+   * the ticket price. Pass searchId (from search()'s result). Returns either
+   * { ok, booked: true, order_id } or, when the booking genuinely could not
+   * complete, { ok, booked: false, booking_url } — hand the link to the user,
+   * nothing was charged.
+   *
+   * Developer API (X-API-Key): charges ticket price + service fee via Stripe,
+   * creates a real PNR. Requires unlock() first. Always provide
+   * idempotencyKey to prevent double-bookings on retry.
    */
   async book(
     offerId: string,
@@ -427,7 +436,27 @@ export class LetsFG {
     contactEmail: string,
     contactPhone = '',
     idempotencyKey = '',
-  ): Promise<BookingResult> {
+    searchId = '',
+  ): Promise<BookingResult | Record<string, unknown>> {
+    this.requireAuth();
+
+    if (this.usingPFS) {
+      if (!searchId) {
+        throw new LetsFGError(
+          'searchId is required to book via PFS — pass the search_id from search()\'s result.',
+          400,
+        );
+      }
+      const passenger = { ...passengers[0] } as Record<string, unknown>;
+      if (contactPhone && !passenger.phone_number) passenger.phone_number = contactPhone;
+      return this.postWithBearer<Record<string, unknown>>('/api/agent-book', {
+        search_id: searchId,
+        offer_id: offerId,
+        passenger,
+        contact_email: contactEmail,
+      });
+    }
+
     this.requireApiKey();
     const body: Record<string, unknown> = {
       offer_id: offerId,


### PR DESCRIPTION
## Summary
- `LetsFG.book()` only ever called the paid Developer API endpoint, even though `search()`/`unlock()` already dispatch on `usingPFS` (Bearer token vs API key) -- same class of bug just fixed in the Python CLI (#185).
- `book()` now takes an optional trailing `searchId` param: when `usingPFS` is true, it calls `POST /api/agent-book` and returns either a confirmed order or a booking link (nothing charged either way). Developer API branch unchanged.
- `cli.ts`'s `cmdBook` only ever constructs `LetsFG` with an `apiKey`, so it always takes the Developer API branch -- added a type cast there since `book()`'s return type is now a union.

## Note
The JS CLI (`sdk/js/src/cli.ts`) itself still doesn't expose the PFS path at all -- `search`/`unlock`/`book` all only take `--api-key`, never a bearer token, unlike the Python CLI. That's a separate, larger piece of work, left untouched in this PR.

## Test plan
- [x] `npm run build` -- clean, no type errors
- [x] `npm test` -- 23/23 existing tests pass
- [x] Smoke-tested both `book()` branches directly against the built dist: PFS branch calls `/api/agent-book` with the right payload (search_id, offer_id, passenger with phone_number merged in, contact_email) and returns the raw result; missing `searchId` throws a clear error