### PR TITLE
release: python 2026.5.89, js 2026.5.65 — fix book() free PFS path

### DIFF
--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "letsfg",
-  "version": "2026.5.62",
+  "version": "2026.5.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "letsfg",
-      "version": "2026.5.62",
+      "version": "2026.5.65",
       "license": "MIT",
       "bin": {
         "letsfg": "dist/cli.js"

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "letsfg",
-  "version": "2026.5.64",
+  "version": "2026.5.65",
   "description": "Flights and hotels for AI agents. Server-side engine covers hundreds of airlines; hotels are real bookable inventory with free cancellation and pay-later terms. Includes open-source ranking engine.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/python/letsfg/__init__.py
+++ b/sdk/python/letsfg/__init__.py
@@ -43,7 +43,7 @@ from letsfg.models import (
 )
 from letsfg.models.flights import PublicFlightOffer, to_public_offer
 
-__version__ = "2026.5.88"
+__version__ = "2026.5.89"
 __all__ = [
     "LetsFG",
     "LetsFGError",

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "letsfg"
-version = "2026.5.88"
+version = "2026.5.89"
 description = "Flights and hotels for AI agents. Server-side engine covers hundreds of airlines; hotels are real bookable inventory with free cancellation and pay-later terms. Free flight search via Bearer token or prepaid Developer API."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
Version bump to release the book()/book command fixes from #185 and #186.

- Python SDK 2026.5.88 -> 2026.5.89
- JS SDK 2026.5.64 -> 2026.5.65 (package-lock.json synced too, it had drifted to 2026.5.62)

## Test plan
- [x] `python -m build` + `twine check dist/*` -- both pass
- [x] `npm run build` + `npm test` -- 23/23 pass