### PR TITLE
release: python 2026.5.90 — fix client.LetsFG.book() free PFS path

### DIFF
--- a/sdk/python/letsfg/__init__.py
+++ b/sdk/python/letsfg/__init__.py
@@ -43,7 +43,7 @@ from letsfg.models import (
 )
 from letsfg.models.flights import PublicFlightOffer, to_public_offer
 
-__version__ = "2026.5.89"
+__version__ = "2026.5.90"
 __all__ = [
     "LetsFG",
     "LetsFGError",

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "letsfg"
-version = "2026.5.89"
+version = "2026.5.90"
 description = "Flights and hotels for AI agents. Server-side engine covers hundreds of airlines; hotels are real bookable inventory with free cancellation and pay-later terms. Free flight search via Bearer token or prepaid Developer API."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump to release the client.py book() fix from #188.