### PR TITLE
Add free PFS auth to the JS CLI, and fix a dead-endpoint bug in unlock()

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts src/cli.ts --format cjs,esm --dts --clean",
-    "test": "tsx --test src/index.test.ts",
+    "test": "tsx --test src/index.test.ts src/auth.test.ts",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/sdk/js/src/auth.test.ts
+++ b/sdk/js/src/auth.test.ts
@@ -61,7 +61,7 @@ describe('requestEnrolment', () => {
     globalThis.fetch = (async () => ({
       status: 402,
       json: async () => ({ setup_url: 'https://checkout.stripe.com/fake', setup_session_id: 'cs_fake' }),
-    })) as typeof fetch;
+    } as Response)) as typeof fetch;
 
     try {
       const { requestEnrolment } = await import('./auth.js');
@@ -77,7 +77,7 @@ describe('requestEnrolment', () => {
     globalThis.fetch = (async () => ({
       status: 500,
       json: async () => ({ error: 'server error' }),
-    })) as typeof fetch;
+    } as Response)) as typeof fetch;
 
     try {
       const { requestEnrolment, BearerTokenError } = await import('./auth.js');
@@ -97,7 +97,7 @@ describe('verifyPaymentMethod', () => {
       return {
         status: 200,
         json: async () => ({ token: 'verified-token', expires_at: '2026-10-27T00:00:00Z' }),
-      };
+      } as Response;
     }) as typeof fetch;
 
     try {
@@ -121,7 +121,7 @@ describe('verifyPaymentMethod', () => {
     globalThis.fetch = (async () => ({
       status: 200,
       json: async () => ({}),
-    })) as typeof fetch;
+    } as Response)) as typeof fetch;
 
     try {
       const { verifyPaymentMethod, BearerTokenError } = await import('./auth.js');

--- a/sdk/js/src/auth.test.ts
+++ b/sdk/js/src/auth.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// auth.ts resolves its config path from APPDATA (win32) or HOME (posix) at
+// call time, so redirecting both env vars to a scratch dir before each test
+// keeps this suite from ever touching a real ~/.letsfg/config.json.
+let scratchDir: string;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'letsfg-auth-test-'));
+  savedEnv = {
+    APPDATA: process.env.APPDATA,
+    HOME: process.env.HOME,
+    LETSFG_BEARER_TOKEN: process.env.LETSFG_BEARER_TOKEN,
+  };
+  process.env.APPDATA = scratchDir;
+  process.env.HOME = scratchDir;
+  delete process.env.LETSFG_BEARER_TOKEN;
+});
+
+afterEach(() => {
+  for (const [key, val] of Object.entries(savedEnv)) {
+    if (val === undefined) delete process.env[key];
+    else process.env[key] = val;
+  }
+  rmSync(scratchDir, { recursive: true, force: true });
+});
+
+describe('getBearerToken / saveToken', () => {
+  it('throws BearerTokenError when nothing is configured', async () => {
+    const { getBearerToken, BearerTokenError } = await import('./auth.js');
+    assert.throws(() => getBearerToken(), BearerTokenError);
+  });
+
+  it('returns LETSFG_BEARER_TOKEN env var immediately, without touching the config file', async () => {
+    process.env.LETSFG_BEARER_TOKEN = 'env-token-123';
+    const { getBearerToken } = await import('./auth.js');
+    assert.equal(getBearerToken(), 'env-token-123');
+  });
+
+  it('round-trips a saved token through the config file', async () => {
+    const { saveToken, getBearerToken } = await import('./auth.js');
+    saveToken('saved-token-456', Date.now() + 90 * 24 * 3600 * 1000);
+    assert.equal(getBearerToken(), 'saved-token-456');
+  });
+
+  it('treats a saved token past its expiry (minus buffer) as invalid', async () => {
+    const { saveToken, getBearerToken, BearerTokenError } = await import('./auth.js');
+    saveToken('expired-token', Date.now() + 1000); // expires in 1s, well inside the 1h buffer
+    assert.throws(() => getBearerToken(), BearerTokenError);
+  });
+});
+
+describe('requestEnrolment', () => {
+  it('returns the body on a 402 response', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => ({
+      status: 402,
+      json: async () => ({ setup_url: 'https://checkout.stripe.com/fake', setup_session_id: 'cs_fake' }),
+    })) as typeof fetch;
+
+    try {
+      const { requestEnrolment } = await import('./auth.js');
+      const data = await requestEnrolment();
+      assert.equal(data.setup_session_id, 'cs_fake');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('throws BearerTokenError on an unexpected status', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => ({
+      status: 500,
+      json: async () => ({ error: 'server error' }),
+    })) as typeof fetch;
+
+    try {
+      const { requestEnrolment, BearerTokenError } = await import('./auth.js');
+      await assert.rejects(() => requestEnrolment(), BearerTokenError);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('verifyPaymentMethod', () => {
+  it('saves and returns the token on success', async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedBody: Record<string, unknown> | undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      capturedBody = JSON.parse(init!.body as string);
+      return {
+        status: 200,
+        json: async () => ({ token: 'verified-token', expires_at: '2026-10-27T00:00:00Z' }),
+      };
+    }) as typeof fetch;
+
+    try {
+      const { verifyPaymentMethod, getBearerToken } = await import('./auth.js');
+      const token = await verifyPaymentMethod({ cardToken: 'tok_test' });
+      assert.equal(token, 'verified-token');
+      assert.equal(capturedBody?.card_token, 'tok_test');
+      assert.equal(getBearerToken(), 'verified-token');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('throws BearerTokenError when no credential option is given', async () => {
+    const { verifyPaymentMethod, BearerTokenError } = await import('./auth.js');
+    await assert.rejects(() => verifyPaymentMethod({}), BearerTokenError);
+  });
+
+  it('throws BearerTokenError when the response has no token', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => ({
+      status: 200,
+      json: async () => ({}),
+    })) as typeof fetch;
+
+    try {
+      const { verifyPaymentMethod, BearerTokenError } = await import('./auth.js');
+      await assert.rejects(() => verifyPaymentMethod({ setupSessionId: 'cs_fake' }), BearerTokenError);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/sdk/js/src/auth.ts
+++ b/sdk/js/src/auth.ts
@@ -1,0 +1,170 @@
+/**
+ * Payment-token authentication for LetsFG Programmatic Flight Search (PFS).
+ *
+ * Nothing is charged to authenticate — it is a zero-amount Stripe setup that
+ * validates and vaults a card, with no charge and no authorization hold.
+ * Having a card on file is what lets an agent go all the way to booking.
+ *
+ * Flow (one-time):
+ *   1. POST /api/agent-access/request  -> 402 { setup_url, setup_session_id }
+ *   2. Present a payment method: a human opens setup_url and adds a card, or
+ *      pass a payment_method_id / card_token you already hold
+ *   3. POST /api/agent-access/verify   -> { token, expires_at } (90-day token)
+ *
+ * Mirrors sdk/python/letsfg/connectors/auth.py.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { join, dirname } from 'node:path';
+
+const BASE_URL = process.env.LETSFG_BASE_URL || 'https://letsfg.co';
+const TOKEN_TTL_MS = 90 * 24 * 3600 * 1000;
+
+export class BearerTokenError extends Error {}
+
+interface StoredConfig {
+  pfs_auth?: { token: string; expires_at: number };
+  [key: string]: unknown;
+}
+
+function configPath(): string {
+  const base = platform() === 'win32' ? (process.env.APPDATA || homedir()) : homedir();
+  return join(base, '.letsfg', 'config.json');
+}
+
+function loadConfig(): StoredConfig {
+  const p = configPath();
+  if (!existsSync(p)) return {};
+  try {
+    return JSON.parse(readFileSync(p, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveConfig(cfg: StoredConfig): void {
+  const p = configPath();
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(cfg, null, 2));
+  try {
+    chmodSync(p, 0o600);
+  } catch {
+    /* best effort — e.g. not supported on Windows */
+  }
+}
+
+/** Return a valid Bearer token, or throw BearerTokenError. */
+export function getBearerToken(): string {
+  const env = process.env.LETSFG_BEARER_TOKEN;
+  if (env) return env;
+
+  const auth = loadConfig().pfs_auth;
+  if (auth?.token && Date.now() < auth.expires_at - 3600_000) {
+    return auth.token;
+  }
+
+  throw new BearerTokenError(
+    'No valid LetsFG Bearer token.\n' +
+    '  Run:  letsfg auth        (adds a payment method — nothing is charged)\n' +
+    '  Or:   export LETSFG_BEARER_TOKEN=<token>'
+  );
+}
+
+/** Save a Bearer token to ~/.letsfg/config.json. */
+export function saveToken(token: string, expiresAt?: number): void {
+  const cfg = loadConfig();
+  cfg.pfs_auth = { token, expires_at: expiresAt ?? Date.now() + TOKEN_TTL_MS };
+  saveConfig(cfg);
+}
+
+async function postJson(path: string, payload: Record<string, unknown>): Promise<{ status: number; data: Record<string, unknown> }> {
+  const resp = await fetch(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': 'LetsFG-js/0.1.0', 'X-Client-Type': 'js-sdk' },
+    body: JSON.stringify(payload),
+  });
+  const data = await resp.json().catch(() => ({})) as Record<string, unknown>;
+  return { status: resp.status, data };
+}
+
+function parseExpiry(raw: unknown): number {
+  if (typeof raw === 'number') return raw * 1000; // epoch seconds -> ms
+  if (typeof raw === 'string') {
+    const ms = Date.parse(raw);
+    if (!Number.isNaN(ms)) return ms;
+  }
+  return Date.now() + TOKEN_TTL_MS;
+}
+
+/** Start enrolment. Returns the 402 body with setup_url / setup_session_id. */
+export async function requestEnrolment(): Promise<Record<string, unknown>> {
+  const { status, data } = await postJson('/api/agent-access/request', {});
+  if (status !== 200 && status !== 402) {
+    throw new BearerTokenError(`Could not start authentication (HTTP ${status}): ${data.error || ''}`);
+  }
+  return data;
+}
+
+/**
+ * Exchange a payment method for a Bearer token. Saves and returns the token.
+ * Pass exactly one of setupSessionId / paymentMethodId / cardToken.
+ */
+export async function verifyPaymentMethod(opts: {
+  setupSessionId?: string;
+  paymentMethodId?: string;
+  cardToken?: string;
+}): Promise<string> {
+  const payload: Record<string, string> = {};
+  if (opts.setupSessionId) payload.setup_session_id = opts.setupSessionId;
+  else if (opts.paymentMethodId) payload.payment_method_id = opts.paymentMethodId;
+  else if (opts.cardToken) payload.card_token = opts.cardToken;
+  else throw new BearerTokenError('Provide one of setupSessionId, paymentMethodId, or cardToken.');
+
+  const { status, data } = await postJson('/api/agent-access/verify', payload);
+  if (status !== 200 || !data.token) {
+    throw new BearerTokenError(`Verification failed (HTTP ${status}). ${data.hint || data.error || ''}`.trim());
+  }
+  const token = data.token as string;
+  saveToken(token, parseExpiry(data.expires_at));
+  return token;
+}
+
+function openBrowser(url: string): void {
+  import('node:child_process').then(({ exec }) => {
+    const cmd = platform() === 'win32' ? `start "" "${url}"` : platform() === 'darwin' ? `open "${url}"` : `xdg-open "${url}"`;
+    exec(cmd, () => { /* best effort, ignore failures */ });
+  }).catch(() => { /* best effort */ });
+}
+
+/**
+ * Interactive auth — call once to get a 90-day Bearer token. Opens Stripe's
+ * hosted card page, waits for you to finish, then verifies. Nothing charged.
+ */
+export async function paymentAuth(openBrowserFlag = true): Promise<string> {
+  console.log('\n  Connecting to LetsFG...');
+  const data = await requestEnrolment();
+
+  const setupUrl = data.setup_url as string | undefined;
+  const sessionId = data.setup_session_id as string | undefined;
+  if (!setupUrl || !sessionId) {
+    throw new BearerTokenError('Server did not return a setup URL. Check https://letsfg.co/for-agents');
+  }
+
+  console.log('\n  LetsFG needs a payment method on file before it can search or book.');
+  console.log('  Nothing is charged now — this is a zero-amount card setup.\n');
+  console.log('  Step 1 — add a card here:\n');
+  console.log(`     ${setupUrl}\n`);
+  if (openBrowserFlag) openBrowser(setupUrl);
+  console.log("  Step 2 — press Enter once you've finished.");
+  const readline = await import('node:readline/promises');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  await rl.question('');
+  rl.close();
+
+  process.stdout.write('  Verifying... ');
+  const token = await verifyPaymentMethod({ setupSessionId: sessionId });
+  const expiresAt = loadConfig().pfs_auth?.expires_at ?? Date.now() + TOKEN_TTL_MS;
+  console.log(`done. Token valid until ${new Date(expiresAt).toISOString().slice(0, 10)}.`);
+  return token;
+}

--- a/sdk/js/src/cli.ts
+++ b/sdk/js/src/cli.ts
@@ -3,12 +3,15 @@
  * LetsFG CLI — Agent-native flight search & booking from terminal.
  *
  * Usage:
+ *   letsfg auth
  *   letsfg search GDN BER 2026-03-03
- *   letsfg unlock off_xxx
- *   letsfg book off_xxx --passenger '{"id":"pas_xxx",...}' --email john@example.com
- *   letsfg register --name my-agent --email agent@example.com
- *   letsfg me
+ *   letsfg book off_xxx --search-id srch_xxx --passenger '{"given_name":"John",...}' --email john@example.com
  *   letsfg locations Berlin
+ *   letsfg me
+ *
+ * Developer API only (separate paid product):
+ *   letsfg unlock off_xxx --api-key trav_...
+ *   letsfg register --name my-agent --email agent@example.com
  */
 
 import {
@@ -19,6 +22,24 @@ import {
   type SearchOptions,
   type BookingResult,
 } from './index.js';
+import { getBearerToken, paymentAuth, BearerTokenError } from './auth.js';
+
+/**
+ * Resolve credentials for a command: an explicit --api-key (or LETSFG_API_KEY
+ * env var) always wins, since passing it is an explicit choice to use the
+ * paid Developer API. Otherwise, fall back to a Bearer token from `letsfg
+ * auth` (env var or ~/.letsfg/config.json) for the free PFS path. Neither
+ * means the SDK's own requireAuth() will raise a clear error.
+ */
+function resolveCredentials(apiKeyFlag?: string): { bearerToken?: string; apiKey?: string } {
+  const apiKey = apiKeyFlag || process.env.LETSFG_API_KEY;
+  if (apiKey) return { apiKey };
+  try {
+    return { bearerToken: getBearerToken() };
+  } catch {
+    return {};
+  }
+}
 
 // ── Arg parsing (zero-dependency) ────────────────────────────────────────
 
@@ -83,7 +104,8 @@ async function cmdSearch(args: string[]) {
     process.exit(1);
   }
 
-  const bt = new LetsFG({ apiKey, baseUrl });
+  const creds = resolveCredentials(apiKey);
+  const bt = new LetsFG({ ...creds, baseUrl });
   const result = await bt.search(origin, destination, date, {
     returnDate,
     adults,
@@ -98,6 +120,7 @@ async function cmdSearch(args: string[]) {
 
   if (jsonOut) {
     console.log(JSON.stringify({
+      search_id: result.search_id,
       passenger_ids: result.passenger_ids,
       total_results: result.total_results,
       offers: result.offers.map(o => ({
@@ -122,6 +145,9 @@ async function cmdSearch(args: string[]) {
   }
 
   console.log(`\n  ${result.total_results} offers  |  ${origin} → ${destination}  |  ${date}`);
+  if (result.search_id) {
+    console.log(`  search_id: ${result.search_id}  (needed for \`letsfg book\`, offers expire ~15 min after search)`);
+  }
   console.log(`  Passenger IDs: ${JSON.stringify(result.passenger_ids)}\n`);
 
   result.offers.forEach((o, i) => {
@@ -129,8 +155,12 @@ async function cmdSearch(args: string[]) {
     console.log(`       ID: ${o.id}`);
   });
 
-  console.log(`\n  To unlock: letsfg unlock <offer_id>`);
-  console.log(`  Passenger IDs needed for booking: ${JSON.stringify(result.passenger_ids)}\n`);
+  if (creds.bearerToken) {
+    console.log(`\n  To book: letsfg book <offer_id> --search-id ${result.search_id} --passenger '{...}' --email you@example.com\n`);
+  } else {
+    console.log(`\n  To unlock: letsfg unlock <offer_id>`);
+    console.log(`  Passenger IDs needed for booking: ${JSON.stringify(result.passenger_ids)}\n`);
+  }
 }
 
 async function cmdUnlock(args: string[]) {
@@ -167,37 +197,58 @@ async function cmdBook(args: string[]) {
   const jsonOut = hasFlag(args, '--json') || hasFlag(args, '-j');
   const apiKey = getFlag(args, '--api-key', '-k');
   const baseUrl = getFlag(args, '--base-url');
+  const searchId = getFlag(args, '--search-id');
   const email = getFlag(args, '--email', '-e') || '';
   const phone = getFlag(args, '--phone') || '';
   const passengerStrs = getAllFlags(args, '--passenger', '-p');
   const offerId = args[0];
 
   if (!offerId || !passengerStrs.length || !email) {
-    console.error('Usage: letsfg book <offer_id> --passenger \'{"id":"pas_xxx",...}\' --email you@example.com');
+    console.error('Usage: letsfg book <offer_id> --search-id <id> --passenger \'{"given_name":"John",...}\' --email you@example.com');
     process.exit(1);
   }
 
   const passengers = passengerStrs.map(s => JSON.parse(s));
-  const bt = new LetsFG({ apiKey, baseUrl });
-  // This CLI only ever constructs LetsFG with an apiKey, never a bearerToken,
-  // so book() always takes the Developer API branch and returns BookingResult.
-  const result = await bt.book(offerId, passengers, email, phone) as BookingResult;
+  const creds = resolveCredentials(apiKey);
+
+  if (creds.bearerToken && !searchId) {
+    console.error('Error: --search-id is required (from your `letsfg search` results) to book via the free PFS path.');
+    process.exit(1);
+  }
+
+  const bt = new LetsFG({ ...creds, baseUrl });
+  const result = await bt.book(offerId, passengers, email, phone, '', searchId);
 
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));
     return;
   }
 
-  if (result.status === 'confirmed') {
+  if ('booked' in result) {
+    // PFS path — free, ticket price only, no LetsFG fee, no unlock step.
+    if (result.booked) {
+      console.log(`\n  ✓ Booking confirmed!`);
+      console.log(`    Order ID: ${result.order_id}`);
+      console.log(`    Charged: ${result.charged ?? 0} ${result.currency ?? ''}\n`);
+    } else {
+      console.log(`\n  Could not complete a confirmed booking. Nothing was charged.`);
+      console.log(`    Booking link: ${result.booking_url ?? '(none)'}\n`);
+    }
+    return;
+  }
+
+  // Developer API path
+  const br = result as BookingResult;
+  if (br.status === 'confirmed') {
     console.log(`\n  ✓ Booking confirmed!`);
-    console.log(`    PNR: ${result.booking_reference}`);
-    console.log(`    Flight: ${result.currency} ${result.flight_price.toFixed(2)}`);
-    console.log(`    Fee: ${result.currency} ${result.service_fee.toFixed(2)} (${result.service_fee_percentage}%)`);
-    console.log(`    Total: ${result.currency} ${result.total_charged.toFixed(2)}`);
-    console.log(`    Order: ${result.order_id}\n`);
+    console.log(`    PNR: ${br.booking_reference}`);
+    console.log(`    Flight: ${br.currency} ${br.flight_price.toFixed(2)}`);
+    console.log(`    Fee: ${br.currency} ${br.service_fee.toFixed(2)} (${br.service_fee_percentage}%)`);
+    console.log(`    Total: ${br.currency} ${br.total_charged.toFixed(2)}`);
+    console.log(`    Order: ${br.order_id}\n`);
   } else {
     console.error(`  ✗ Booking failed`);
-    console.error(JSON.stringify(result.details, null, 2));
+    console.error(JSON.stringify(br.details, null, 2));
     process.exit(1);
   }
 }
@@ -234,6 +285,21 @@ async function cmdLocations(args: string[]) {
     const country = loc.country || '';
     console.log(`  ${iata}  ${name} (${type}) — ${city}, ${country}`);
   }
+}
+
+async function cmdAuth(args: string[]) {
+  const cardToken = getFlag(args, '--card-token');
+  const paymentMethodId = getFlag(args, '--payment-method');
+  const noBrowser = hasFlag(args, '--no-browser');
+
+  if (cardToken || paymentMethodId) {
+    const { verifyPaymentMethod } = await import('./auth.js');
+    await verifyPaymentMethod({ cardToken: cardToken || undefined, paymentMethodId: paymentMethodId || undefined });
+    console.log('\n  ✓ Authenticated. Nothing was charged.');
+  } else {
+    await paymentAuth(!noBrowser);
+  }
+  console.log('\n  You\'re all set. Run: letsfg search WAW BCN 2026-07-15\n');
 }
 
 async function cmdRegister(args: string[]) {
@@ -323,11 +389,11 @@ Authenticate once with letsfg auth — a zero-amount card setup, nothing is
 charged — then search and book.
 
 Commands:
-  auth                            Put a card on file -> 90-day token. Nothing charged
-  search <origin> <dest> <date>   Search for flights (free)
-  locations <query>               Resolve city name to IATA codes
-  book <offer_id> --passenger ... Book a flight. No LetsFG fee
-  me                              Show agent profile
+  auth                             Put a card on file -> 90-day token. Nothing charged
+  search <origin> <dest> <date>    Search for flights (free), prints search_id
+  locations <query>                Resolve city name to IATA codes
+  book <offer_id> --search-id ...  Book a flight. No LetsFG fee, no unlock step
+  me                               Show agent profile
 
 Developer API only (a SEPARATE paid product — most agents should not use these;
 they create a billing account. Use auth above instead):
@@ -336,14 +402,17 @@ they create a billing account. Use auth above instead):
   unlock <offer_id>               [Developer API only] Unlock offer — 1% of ticket (min $3)
 
 Options:
-  --json, -j       Output raw JSON
-  --api-key, -k    API key (or set LETSFG_API_KEY)
-  --base-url       API URL (default: https://letsfg.co/developers)
+  --json, -j          Output raw JSON
+  --api-key, -k       Developer API key (or set LETSFG_API_KEY) — switches book/search to the paid path
+  --base-url          API URL (default: https://letsfg.co)
+  --card-token        (auth only) Stripe tok_... you already hold, for a headless auth
+  --payment-method    (auth only) Stripe pm_... you already hold, for a headless auth
+  --no-browser        (auth only) Don't try to auto-open the card setup page
 
 Examples:
   letsfg auth
   letsfg search GDN BER 2026-03-03 --sort price
-  letsfg book off_xxx -p '{"given_name":"Ada",...}' -e ada@example.com
+  letsfg book off_xxx --search-id srch_xxx -p '{"given_name":"Ada","family_name":"Lovelace","born_on":"1990-04-01","gender":"f"}' -e ada@example.com
 `;
 
 async function main() {
@@ -352,6 +421,9 @@ async function main() {
 
   try {
     switch (command) {
+      case 'auth':
+        await cmdAuth(args);
+        break;
       case 'search':
         await cmdSearch(args);
         break;
@@ -385,7 +457,7 @@ async function main() {
         process.exit(1);
     }
   } catch (e) {
-    if (e instanceof LetsFGError) {
+    if (e instanceof LetsFGError || e instanceof BearerTokenError) {
       console.error(`Error: ${e.message}`);
       process.exit(1);
     }

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -407,14 +407,12 @@ export class LetsFG {
 
   /**
    * Unlock a flight offer — confirms live price, reveals direct airline booking URL.
-   * Cost: 1% of ticket price, min $3. Free with Developer API.
+   * Cost: 1% of ticket price, min $3. Developer API only — there is no unlock
+   * endpoint on a PFS Bearer token, so PFS callers use book() directly.
    */
   async unlock(offerId: string): Promise<UnlockResult> {
-    this.requireAuth();
-    const path = this.usingPFS
-      ? '/api/unlock'
-      : '/developers/api/v1/bookings/unlock';
-    return this.postWithAuth<UnlockResult>(path, { offer_id: offerId });
+    this.requireApiKey();
+    return this.post<UnlockResult>('/developers/api/v1/bookings/unlock', { offer_id: offerId });
   }
 
   /**


### PR DESCRIPTION
## Summary
The JS CLI's `search`/`unlock`/`book` commands only ever took `--api-key` -- there was no way to use the free PFS path from this CLI at all, unlike the Python CLI. Its own `--help` text already described a `letsfg auth` command and a fee-free `book`, but neither was actually wired up.

- Added `sdk/js/src/auth.ts` (mirrors `sdk/python/letsfg/connectors/auth.py`): token persistence to `~/.letsfg/config.json` (`%APPDATA%` on Windows), the `POST /api/agent-access/request` -> `verify` enrolment flow, and an interactive `payment_auth()` that opens the card setup page and waits for Enter.
- Wired a new `letsfg auth` command into `cli.ts`, plus a `resolveCredentials()` helper so `search`/`book` prefer a Bearer token (env var or saved config) unless `--api-key`/`LETSFG_API_KEY` is explicitly set, in which case that wins (explicit choice to use the paid path).
- `book` gained `--search-id` and now handles both the PFS result shape (`{booked, order_id | booking_url}`) and the Developer API `BookingResult` shape.

## Also found and fixed
While auditing `unlock()`, found it had a PFS branch posting to `/api/unlock`, which doesn't exist in the private repo's routes (confirmed against `website/app/api/` -- only `/developers/api/v1/bookings/unlock` is real). `unlock()` is Developer-API-only, same as the Python client -- there's no unlock step on a PFS Bearer token at all -- so this was a dead endpoint no correctly-behaving caller would hit, but a rough edge for anyone who tried it anyway.

## Test plan
- [x] `npm run build` -- clean, no type errors
- [x] `npm test` -- 23/23 existing tests pass
- [x] Isolated smoke test of `auth.ts`'s `verifyPaymentMethod`/`getBearerToken` with the config path redirected to a scratch dir (mocked network) -- confirmed token round-trips correctly and the real `%APPDATA%\.letsfg\` was never touched
- [x] End-to-end test of the built CLI against the real network with a garbage Bearer token (`letsfg search ...`) -- resolved credentials correctly, got a clean 401 error, no crash
- [x] `letsfg book` without `--search-id` on the PFS path errors clearly instead of silently misbehaving