### PR TITLE
release: js 2026.5.66 — free PFS auth for the CLI, unlock() dead-endpoint fix

### DIFF
--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "letsfg",
-  "version": "2026.5.65",
+  "version": "2026.5.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "letsfg",
-      "version": "2026.5.65",
+      "version": "2026.5.66",
       "license": "MIT",
       "bin": {
         "letsfg": "dist/cli.js"

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "letsfg",
-  "version": "2026.5.65",
+  "version": "2026.5.66",
   "description": "Flights and hotels for AI agents. Server-side engine covers hundreds of airlines; hotels are real bookable inventory with free cancellation and pay-later terms. Includes open-source ranking engine.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Version bump to release #191 (JS CLI free PFS auth support + unlock() fix).