### PR TITLE
ci: Fix shell injection vector and pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Actions are pinned to immutable commit SHAs (supply-chain hardening), which
+# means they no longer follow the upstream major tag. Dependabot is what keeps
+# them current: it bumps the SHA and rewrites the trailing "# vX.Y.Z" comment.
+# Without this file, a pinned action stays frozen forever — including through
+# upstream security fixes.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,9 +15,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,9 +15,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: '3.12'
 

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -16,8 +16,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.12'
       - name: Install SDK (no connector deps — browser binaries not available in CI)

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -16,8 +16,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: '3.12'
       - name: Install SDK (no connector deps — browser binaries not available in CI)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
       matrix:
         package: [sdk/js, sdk/mcp]
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           cache: npm
@@ -51,11 +51,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-test-gate')
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Check new source files have tests
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
 
@@ -63,7 +65,6 @@ jobs:
           WATCH_PATHS="sdk/js/src sdk/mcp/src"
 
           # Get files Added (A) or Renamed (R) in this PR vs base branch
-          BASE_REF="${{ github.base_ref }}"
           NEW_FILES=$(git diff --name-only --diff-filter=AR "origin/$BASE_REF"...HEAD | \
             grep -E '\.(ts|tsx)$' | \
             grep -v '\.test\.(ts|tsx)$' | \
@@ -118,8 +119,8 @@ jobs:
       run:
         working-directory: sdk/python
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.12'
       - name: Install package + pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
       matrix:
         package: [sdk/js, sdk/mcp]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: '20'
           cache: npm
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-test-gate')
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
 
@@ -63,7 +63,8 @@ jobs:
           WATCH_PATHS="sdk/js/src sdk/mcp/src"
 
           # Get files Added (A) or Renamed (R) in this PR vs base branch
-          NEW_FILES=$(git diff --name-only --diff-filter=AR "origin/${{ github.base_ref }}"...HEAD | \
+          BASE_REF="${{ github.base_ref }}"
+          NEW_FILES=$(git diff --name-only --diff-filter=AR "origin/$BASE_REF"...HEAD | \
             grep -E '\.(ts|tsx)$' | \
             grep -v '\.test\.(ts|tsx)$' | \
             grep -v '\.d\.ts$' || true)
@@ -117,8 +118,8 @@ jobs:
       run:
         working-directory: sdk/python
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: '3.12'
       - name: Install package + pytest


### PR DESCRIPTION
Hey! 👋 I was exploring LetsFG and ran the repository through a security and architecture scanner we are building called [VibeMass](https://vibemass.com). 

I noticed a couple of CI/CD vulnerabilities in your workflows, so I wanted to quickly patch them for you!

### 1. Security Fix: Shell Injection in `test.yml`
In `.github/workflows/test.yml`, the `github.base_ref` variable was being directly interpolated into a `run:` shell command. While `base_ref` is somewhat constrained, interpolating context variables directly into bash scripts is a known shell injection vector if branch names are ever manipulated. 
**Fix:** I bound the variable to an intermediate `env` context first, which safely passes it to the shell.

### 2. Security Fix: Mutable GitHub Action Tags
Workflows like `docs.yml` and `test.yml` were using mutable tags like `@v4` and `@v5`. If any of those upstream action repositories are ever compromised, an attacker could silently inject malware into your builds. 
**Fix:** I’ve pinned your GitHub Actions to their exact 40-character commit SHAs to guarantee supply chain security.

### 3. AI Agent Instructions Heads-Up (No Action Required)
As a side note, the scanner's AI Reliability agent flagged a few really interesting things regarding your `SKILL.md` and `AGENTS.md` files:
- **Conflicting Pricing/Unlock Instructions:** The agent found contradictory statements across `SKILL.md` and `CLAUDE.md` regarding whether the "unlock" step is free, charged via MPP, or developer-only. You might want to harmonize this, as autonomous agents get easily confused by conflicting context and might fail bookings.
- **Missing Idempotency:** It also flagged that the `book_hotel` operation is strictly non-idempotent. While the docs tell the agent to poll on timeout, relying on LLM adherence for chargeable actions without a server-side idempotency key is a massive operational risk for duplicate charges.

Let me know if you have any questions. Awesome project! 🚀
