### PR TITLE
docs: one credential covers flights AND hotels

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,11 +1,14 @@
 {
   "letsfg": {
     "command": "npx",
-    "args": ["-y", "letsfg-mcp"],
+    "args": [
+      "-y",
+      "letsfg-mcp"
+    ],
     "env": {
-      "LETSFG_API_KEY": "${LETSFG_API_KEY}"
+      "LETSFG_BEARER_TOKEN": "${LETSFG_BEARER_TOKEN}"
     },
-    "description": "Flight and hotel search & booking for AI agents. Server-side engine covers hundreds of airlines with per-flight reliability history, plus real bookable hotel rates with free cancellation and pay-later terms. Hotel booking charges a 5% non-refundable reservation fee; the balance is paid to the supplier by balance_due_by. Set LETSFG_API_KEY to reach both flights and hotels, or LETSFG_BEARER_TOKEN (from `letsfg auth`) for free flight-only access — set one, not both.",
+    "description": "Flight and hotel search & booking for AI agents. Server-side engine covers hundreds of airlines with per-flight reliability history, plus real bookable hotel rates with free cancellation and pay-later terms. ONE credential covers both: the free token from `letsfg auth` (zero-amount card setup, nothing charged) or a Developer API key. Hotels need a card on file — which `letsfg auth` already puts there — and booking charges a 5% non-refundable reservation fee, balance paid to the supplier by balance_due_by.",
     "homepage": "https://letsfg.co",
     "repository": "https://github.com/LetsFG/LetsFG"
   }

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ When you're ready to integrate it into your own agent, keep reading.
 | **CLI / Python SDK / npm** | ✅ Free (`letsfg auth`, zero-amount card setup) | No LetsFG fee either way | 5% non-refundable reservation fee | Our servers |
 | **MCP Server** | ✅ Free (`letsfg auth`) | No LetsFG fee either way | 5% reservation fee | Our servers |
 | **PFS** (raw API via letsfg.co) | ✅ Free (Bearer token, zero-amount setup or $0.01 via MPP) | No LetsFG fee either way | 5% reservation fee | Our servers |
-| **Developer API** | Prepaid credits | Included (direct airline URLs) | — (flights only) | Our servers |
+| **Developer API** | Prepaid credits | Included (direct airline URLs) | 5% reservation fee | Our servers |
 
 **CLI / SDK / MCP / PFS = free search, no LetsFG fee on flight booking.** Run `letsfg auth` once (a zero-amount card setup — nothing is charged) and both searching and booking are free for 90 days. No credits, no unlock step. `letsfg book` / `POST /api/agent-book` returns either a confirmed order or a direct airline link — no LetsFG fee either way (you still pay the ticket price itself, plus Stripe's own processing cut, same as any card charge).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -62,7 +62,7 @@ Resolve a place name to the supplier city id that hotel search needs.
 Search real, bookable hotel inventory.
 - **Cost:** FREE, but a payment method on file is REQUIRED — for search, not just booking. A hotel
   search opens a real session at the supplier, so it returns HTTP 402 without a card.
-- **Auth:** Developer API key (`X-API-Key`) only. The PFS Bearer token used for flights is rejected.
+- **Auth:** Either a Developer API key (`X-API-Key`) or the free PFS token from `letsfg auth`. The same card authorises flights and hotels.
 - **Endpoint:** `POST /api/v1/hotels/search`
 - **Input:** city_id, city_name, check_in, check_out, adults, children, child_ages, nationality, limit
 - **Output:** hotels[] each with offers[] carrying `price` (what the guest pays),

--- a/agent-skills-contribution/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
+++ b/agent-skills-contribution/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
@@ -5,9 +5,8 @@ description: >-
   prices from airlines and the major booking sites, with per-flight reliability history. Use when user asks to
   "find flights", "search flights", "book a flight", "compare airline prices",
   "find cheap flights", "fly from X to Y", or any flight-related travel query.
-  Hotels need a Developer API key (the flight Bearer token does not reach them) and a card
-  on file for search as well as booking. Do NOT use for car rentals or non-flight,
-  non-hotel travel bookings.
+  Hotels need a card on file for search as well as booking; either credential
+  reaches them. Do NOT use for car rentals or non-flight, non-hotel travel bookings.
 license: MIT
 metadata:
   author: LetsFG - github.com/LetsFG

--- a/agent-skills-contribution/packages/skills-catalog/skills/(tooling)/letsfg/references/mcp-setup.md
+++ b/agent-skills-contribution/packages/skills-catalog/skills/(tooling)/letsfg/references/mcp-setup.md
@@ -150,7 +150,7 @@ export LETSFG_API_KEY=trav_your_api_key
 | `unlock_flight_offer` | Confirm live price and reserve for 30 min. **[Developer API only]** — on a Bearer token call `book_flight` directly |
 | `book_flight` | Book with passenger details |
 
-**Hotels** — every hotel tool needs `LETSFG_API_KEY`; a Bearer token is rejected with 401.
+**Hotels** — need a card on file (a search opens a real supplier session). Either credential works.
 
 | Tool | Description |
 |------|-------------|

--- a/context7.json
+++ b/context7.json
@@ -3,8 +3,8 @@
   "projectTitle": "LetsFG — flights and hotels for AI agents",
   "description": "Search and book flights across hundreds of airlines and booking sites, plus real bookable hotel rates with free cancellation and pay-later terms. Python, JS and MCP.",
   "rules": [
-    "Flights use a free PFS Bearer token from `letsfg auth`. Hotels do NOT: every hotel endpoint authenticates on a Developer API key (X-API-Key) and rejects the Bearer token with 401.",
-    "Hotels require a payment method on file for SEARCH as well as booking. A hotel search opens a real session at the supplier, so it returns 402 without a card.",
+    "One credential covers flights AND hotels: the free PFS Bearer token from `letsfg auth`, or a Developer API key. Hotel endpoints resolve either (require_api_key_or_pfs_token) — the same card authorises both products.",
+    "Hotels require a payment method on file for SEARCH as well as booking — a hotel search opens a real session at the supplier, so it returns 402 without a card. `letsfg auth` already puts one there, so an agent that enrolled for flights is already set up for hotels.",
     "Hotel booking is asynchronous. POST /hotels/book returns a booking_job_id, not a booking. Poll GET /hotels/booking/{job_id} until status is succeeded or failed.",
     "Never retry a hotel booking blindly. Calling /hotels/book twice for the same rate books the room twice and charges two reservation fees. Poll the job instead.",
     "Hotel booking charges 5% of the price to the card as a NON-REFUNDABLE reservation fee. The balance is paid directly to the supplier via the returned pay_link by balance_due_by.",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,8 +23,8 @@
 | Public Developer API | Managed cloud search, products, teams, no per-booking fee | Register, attach Stripe, top up balance | Prepaid credits | Direct airline URLs, no fee |
 | Hotels | Booking a room, not a flight | Developer API key + card on file | Free search, card required | 5% at booking, balance via pay link |
 
-**Hotels are the one exception to the warning above.** They authenticate on a Developer API key and
-reject the PFS Bearer token, so an agent that only ran `letsfg auth` cannot reach them yet. See
+**Hotels work on the same credential.** They accept either the PFS token from `letsfg auth` or a
+Developer API key, and need a card on file — which `letsfg auth` already puts there. See
 [Hotels](hotels.md).
 
 ## Option A: Free search with Bearer token

--- a/docs/hotels.md
+++ b/docs/hotels.md
@@ -3,10 +3,10 @@
 Hotels are live. Your agent can search real bookable inventory, book a room, and
 hand the guest a pay link — with the same Developer API key it uses for flights.
 
-!!! warning "Hotels need an X-API-Key, not the PFS Bearer token"
-    The Bearer token used for programmatic flight search is rejected by every
-    hotel endpoint. If you only hold a Bearer token you cannot book a hotel yet.
-    This asymmetry is being closed; today it is simply how it works.
+!!! note "One credential covers flights and hotels"
+    The same token you use for programmatic flight search reaches every hotel
+    endpoint too — a Developer API key also works. Hotels do require a card on
+    file for search as well as booking, which `letsfg auth` already provides.
 
 ## How you pay
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ The canonical public surfaces are:
 
 ## Hotels
 
-Hotels are live: real bookable inventory, free-cancellation and pay-later rates only, 5% charged at booking as a non-refundable reservation fee and the balance paid straight to the supplier through a pay link. They need a Developer API key and a card on file for every call, search included. Start at [Hotels](hotels.md).
+Hotels are live: real bookable inventory, free-cancellation and pay-later rates only, 5% charged at booking as a non-refundable reservation fee and the balance paid straight to the supplier through a pay link. They need a card on file for every call, search included — and either credential reaches them: the free token from `letsfg auth` or a Developer API key. Start at [Hotels](hotels.md).
 
 ## Start from the right page
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -15,15 +15,15 @@ LetsFG is available as a Python SDK, JavaScript SDK, MCP server, and remote MCP 
 
 ## Overview
 
-Every package below covers **flights and hotels**. Hotels need a Developer API key (the PFS Bearer token does not reach them) and a card on file for search as well as booking — see [Hotels](hotels.md).
+Every package below covers **flights and hotels**, on **one credential**: the free token from `letsfg auth`, or a Developer API key. Hotels additionally need a card on file for search as well as booking — which `letsfg auth` already provides — see [Hotels](hotels.md).
 
 | Package | Install | What it is | API Key Required? |
 |---------|---------|------------|-------------------|
 | **Python SDK + CLI** | `pip install letsfg` | SDK + CLI, server-side search via letsfg.co | Free Bearer token (`letsfg auth`) or Developer API key |
 | **JS/TS SDK + CLI** | `npm install -g letsfg` | SDK + `letsfg` CLI command | Free Bearer token or Developer API key |
 | **MCP Server** | `npx letsfg-mcp` | Model Context Protocol for AI agents | Free Bearer token or Developer API key |
-| **Remote MCP** | `https://letsfg.co/developers/api/mcp` | Streamable HTTP — no install needed | Developer API key |
-| **Smithery** | [smithery.ai/servers/letsfg](https://smithery.ai/servers/letsfg) | One-click MCP install | Developer API key (flights + hotels) or Bearer token (flights only) |
+| **Remote MCP** | `https://letsfg.co/developers/api/mcp` | Streamable HTTP — no install needed | Free token or Developer API key |
+| **Smithery** | [smithery.ai/servers/letsfg](https://smithery.ai/servers/letsfg) | One-click MCP install | Free token or Developer API key |
 
 ## Python SDK
 
@@ -87,7 +87,7 @@ npx letsfg-mcp
 
 The MCP server connects to the letsfg.co server-side engine. Add `LETSFG_BEARER_TOKEN` (from `letsfg auth`) for free flight search, or `LETSFG_API_KEY` for the Developer API and all hotel tools.
 
-> **Set one, not both.** If both are present the Bearer token takes precedence, and every hotel tool then fails with 401.
+> Either credential reaches **both** flights and hotels. If both are set, the Bearer token is used.
 
 ### Configuration
 
@@ -111,8 +111,8 @@ Add to your MCP config (Claude Desktop, Cursor, etc.):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LETSFG_BEARER_TOKEN` | (none) | Bearer token from `letsfg auth` (free PFS flight search and booking). **Flights only** — hotel tools reject it with 401 |
-| `LETSFG_API_KEY` | (none) | Developer API key. The only mode that reaches **both flights and hotels**; also required for unlock, account and payment tools |
+| `LETSFG_BEARER_TOKEN` | (none) | Free token from `letsfg auth` (zero-amount card setup). Reaches **flights and hotels** |
+| `LETSFG_API_KEY` | (none) | Developer API key (prepaid credits). Also reaches both; required for the account and payment tools |
 | `LETSFG_BASE_URL` | `https://letsfg.co/developers` | Override the website-owned public API base |
 
 ### Remote MCP (Streamable HTTP)
@@ -123,7 +123,7 @@ If your client supports remote MCP servers, connect directly without installing 
 https://letsfg.co/developers/api/mcp
 ```
 
-Remote MCP follows the same paid public API lifecycle as direct REST usage: register, attach Stripe, top up prepaid balance, then search.
+Remote MCP accepts the same free token as the local server — run `letsfg auth` once and point your client at the URL. A Developer API key also works.
 
 For the exact onboarding flow, use [Onboarding and Billing](api-onboarding.md).
 
@@ -138,7 +138,7 @@ For the exact onboarding flow, use [Onboarding and Billing](api-onboarding.md).
 | `unlock_flight_offer` | Confirm price and reserve. **[Developer API only]** — not part of the agent flow; on a Bearer token call `book_flight` directly | API key |
 | `book_flight` | Create the airline booking | Bearer or API key |
 
-**Hotels** — every hotel tool needs `LETSFG_API_KEY`; a Bearer token is rejected with 401.
+**Hotels** — need a card on file (a search opens a real supplier session). Either credential works.
 
 | Tool | Description | Auth |
 |------|-------------|------|
@@ -164,7 +164,7 @@ For the exact onboarding flow, use [Onboarding and Billing](api-onboarding.md).
 | Path | Search mode | Auth | Best for |
 |------|-------------|------|----------|
 | `npx letsfg-mcp` | Server-side at letsfg.co | Bearer token (`letsfg auth`) or Developer API key | Free search in Claude, Cursor, and Windsurf |
-| `https://letsfg.co/developers/api/mcp` | Server-side at letsfg.co | Developer API key required | Account-managed search through the paid public API |
+| `https://letsfg.co/developers/api/mcp` | Server-side at letsfg.co | Free token or Developer API key | No install — flights and hotels over Streamable HTTP |
 
 ## API Endpoints
 

--- a/docs/quickstart-claude.md
+++ b/docs/quickstart-claude.md
@@ -126,7 +126,7 @@ The local MCP server sends search requests to the letsfg.co server-side engine u
 | "Find flights from London to Barcelona next Friday" | `search_flights` → returns offers with prices |
 | "What's the cheapest way to get from NYC to Tokyo?" | `resolve_location` → `search_flights` |
 | "Book the Ryanair one for John Doe" | `unlock_flight_offer` → `book_flight` |
-| "Search hotels in Barcelona for Apr 1-5" | `resolve_hotel_city` → `search_hotels` → rooms + prices. Needs a Developer API key and a card on file, for search as well as booking. |
+| "Search hotels in Barcelona for Apr 1-5" | `resolve_hotel_city` → `search_hotels` → rooms + prices. Needs a card on file, for search as well as booking — `letsfg auth` already provides one. |
 | "Am I verified?" | `get_agent_profile` → shows star status |
 
 ## Troubleshooting

--- a/docs/quickstart-windsurf.md
+++ b/docs/quickstart-windsurf.md
@@ -117,7 +117,7 @@ Cascade can chain LetsFG tools in multi-step flows:
 Cascade will:
 1. `search_flights("LON", "IST", "2026-04-10", return: "2026-04-15")`
 2. `resolve_hotel_city("Istanbul")` then `search_hotels(city_id, city_name, "2026-04-10", "2026-04-15")`
-   — hotels need a Developer API key (not the PFS Bearer token) and a card on file
+   — hotels need a card on file; either credential reaches them
 3. Present both results together
 
 ## Troubleshooting

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Pick ONE auth mode. LETSFG_API_KEY alone reaches flights AND hotels. A Bearer token makes flight search free but cannot reach hotel tools — and if BOTH vars are set the Bearer token wins and every hotel tool returns 401.",
+  "_comment": "One credential reaches BOTH flights and hotels: the free token from `letsfg auth` (LETSFG_BEARER_TOKEN) or a Developer API key (LETSFG_API_KEY). Hotels additionally need a card on file, which `letsfg auth` already provides. If both vars are set the Bearer token is used.",
   "mcpServers": {
     "letsfg": {
       "command": "npx",
@@ -8,7 +8,7 @@
         "letsfg-mcp"
       ],
       "env": {
-        "LETSFG_API_KEY": "YOUR_API_KEY_HERE"
+        "LETSFG_BEARER_TOKEN": "YOUR_FREE_TOKEN_HERE (run `letsfg auth`) — or use LETSFG_API_KEY"
       }
     }
   }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,7 +7,7 @@ info:
     plus real bookable hotel inventory — built for AI agents (OpenClaw, Perplexity Computer,
     Claude, Cursor, Windsurf) and developers.
 
-    Hotels authenticate on a Developer API key (X-API-Key) and reject the PFS Bearer token.
+    Hotels accept either a Developer API key (X-API-Key) or the free PFS token — the same card authorises both.
     They require a card on file for every call, search included, and booking charges a 5%
     non-refundable reservation fee with the balance paid directly to the supplier.
 

--- a/server.json
+++ b/server.json
@@ -20,14 +20,14 @@
       "environmentVariables": [
         {
           "name": "LETSFG_BEARER_TOKEN",
-          "description": "Free PFS Bearer token from `letsfg auth` (zero-amount card setup, nothing charged, 90-day token). Covers flight search and booking. Hotel tools do not accept it — they need LETSFG_API_KEY.",
+          "description": "Free token from `letsfg auth` (zero-amount card setup, nothing charged, 90-day token). Reaches both flights and hotels — the same card authorises both products.",
           "isRequired": false,
           "format": "string",
           "isSecret": true
         },
         {
           "name": "LETSFG_API_KEY",
-          "description": "Developer API key (prepaid credits) from letsfg.co/developers. Required for all hotel tools, and for unlock_flight_offer, resolve_location and get_agent_profile.",
+          "description": "Developer API key (prepaid credits) from letsfg.co/developers. Also reaches both flights and hotels; required for the account and payment tools.",
           "isRequired": false,
           "format": "string",
           "isSecret": true

--- a/skills/hotel-search/SKILL.md
+++ b/skills/hotel-search/SKILL.md
@@ -109,7 +109,7 @@ MCP tools, in call order: `resolve_hotel_city` → `search_hotels` → `book_hot
 
 | Status | Meaning | What to do |
 |--------|---------|------------|
-| `401` | Bearer token used, or bad key | Hotels need a Developer API key |
+| `401` | Credential invalid or expired | Re-run `letsfg auth`, or check the API key |
 | `402` | No payment method on file | Attach a card; required for search too |
 | `409` | The chosen rate is gone | Search again and pick another |
 | `504` | Supplier did not answer in time | If booking, poll the job — do NOT re-book |

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -9,10 +9,10 @@ startCommand:
     properties:
       LETSFG_API_KEY:
         type: string
-        description: "LetsFG Developer API key (prepaid credits). Get one at letsfg.co/developers. This is the only mode that reaches BOTH flights and hotels — all hotel tools require it. Hotel search and booking also need a card on file, and booking charges a 5% non-refundable reservation fee."
+        description: "LetsFG Developer API key (prepaid credits). Get one at letsfg.co/developers. Reaches both flights and hotels. Not needed if you set LETSFG_BEARER_TOKEN — the free token reaches both too."
       LETSFG_BEARER_TOKEN:
         type: string
-        description: "LetsFG PFS Bearer token for FREE flight search and booking. Get one via 'letsfg auth' (zero-amount card setup, nothing charged, 90-day token). Flights only — hotel tools reject it with 401. Set this OR LETSFG_API_KEY, never both: the Bearer token takes precedence and would break every hotel tool."
+        description: "FREE token for flights AND hotels. Get one via 'letsfg auth' (zero-amount card setup, nothing charged, 90-day token). The same card authorises both products, so no Developer API account is needed. Hotel booking charges a 5% non-refundable reservation fee; the balance is paid to the hotel later by link."
     required: []
   commandFunction: |-
     (config) => ({


### PR DESCRIPTION
Fourteen places across the docs, manifests and OpenAPI spec claimed hotels authenticate on a Developer API key only and **"reject the PFS Bearer token with 401"**. That has been false since **2026-08-09**.

`hotels_tbo.py`'s `require_hotel_payment` depends on `require_api_key_or_pfs_token`, and its docstring records the decision verbatim:

> Accepts either a Developer API key OR a PFS payment-token Bearer (Adam, 2026-08-09: "PFS should be the same service as our Hotels... without any separate login")

**Verified live, not inferred.** `POST /hotels/destinations` returns two *different* errors for the two credential shapes — a PFS-shaped Bearer gets `"Invalid or expired token. Re-enrol at POST /api/agent-access/request"`, i.e. it went down the PFS validation path, while an API-key-shaped value gets the API-key error.

Some of these lines were mine, added earlier today: I took `context7.json`'s rule as ground truth and propagated it into `.mcp.json`, `mcp-config.json`, `smithery.yaml` and `docs/packages.md` — including a *"set one, not both — the Bearer token wins and every hotel tool returns 401"* warning that describes a failure that does not happen.

Flights now accept either credential too (LetsFG-private #71, live as `letsfg-api-00509-c6h`), so the remote MCP endpoint no longer needs a paid account either — `packages.md` said "Developer API key required" for it.

Swept: `.mcp.json`, `mcp-config.json`, `context7.json`, `server.json`, `smithery.yaml`, `openapi.yaml`, `SKILL.md`, `README.md`, `docs/{packages,hotels,getting-started,index,quickstart-claude,quickstart-windsurf}.md`, `skills/hotel-search/SKILL.md`, both skills-catalog files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)