### PR TITLE
Fix broken Smithery badge (returns HTTP 500)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ LetsFG gives your AI agent flight **and hotel** search and booking superpowers. 
 [![PyPI](https://img.shields.io/pypi/v/letsfg)](https://pypi.org/project/letsfg/)
 [![npm](https://img.shields.io/npm/v/letsfg-mcp?label=npm%20%28MCP%29)](https://www.npmjs.com/package/letsfg-mcp)
 [![Connector Health](https://letsfg.co/developers/api/v1/analytics/connectors/health/badge)](https://letsfg.co/developers/connectors/health)
-[![smithery badge](https://smithery.ai/badge/letsfg)](https://smithery.ai/servers/letsfg)
+[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/com.boostedchat/travel.svg)](https://skillselion.com/mcp/tool/com.boostedchat/travel)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 <br>


### PR DESCRIPTION
The Smithery badge in the README is serving **HTTP 500**, so it renders as a broken image:

```
https://smithery.ai/badge/letsfg   ->  500
```

This isn't specific to this repo — Smithery's badge endpoint is failing across the ecosystem.

**What this PR does:** removes that one dead badge line, and offers ours in its place.

```markdown
[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/com.boostedchat/travel.svg)](https://skillselion.com/mcp/tool/com.boostedchat/travel)
```

We'd be happy to have ours sit there instead — Skillselion is an independent directory of agent skills and MCP servers, and this project is already listed at https://skillselion.com/mcp/tool/com.boostedchat/travel whether or not you take the badge.

**Entirely your call, and no hard feelings either way:**
- Happy for the badge to stay → merge as is.
- Prefer the dead badge just gone → say so and I'll amend this to a removal-only change.
- Prefer nothing touched → close it, no reply needed.

Only the dead Smithery image was changed. Any other badges in your README were left untouched.
