### PR TITLE
fix(mcp): the required sdk/mcp check passes again

### DIFF
--- a/sdk/mcp/src/index.test.ts
+++ b/sdk/mcp/src/index.test.ts
@@ -164,10 +164,16 @@ describe('MCP server — tools/list', () => {
     assert.ok(Array.isArray(tools), 'tools should be an array');
 
     const toolNames = tools.map(t => t.name);
-    const requiredTools = ['search_flights', 'resolve_location', 'unlock_flight_offer', 'book_flight'];
+    // get_flight_booking and answer_booking_question are how a booking this package
+    // starts is followed to its PNR, and answered when it pauses at a seat map,
+    // a paid extra or a price change.
+    const requiredTools = ['search_flights', 'resolve_location', 'book_flight', 'get_flight_booking', 'answer_booking_question'];
     for (const name of requiredTools) {
       assert.ok(toolNames.includes(name), `missing required tool: ${name}`);
     }
+    // Retired 2026-09-08 and delisted: a tool in the list is a claim a model chooses
+    // from, and one called "unlock" says booking needs a step that no longer exists.
+    assert.ok(!toolNames.includes('unlock_flight_offer'), 'unlock_flight_offer is retired and must not be listed');
   });
 
   it('each tool has name, description, and inputSchema', async () => {
@@ -206,6 +212,33 @@ describe('MCP server — tools/list', () => {
     const props = inputSchema.properties as Record<string, unknown>;
     assert.ok(props.departure_time_from, 'departure_time_from should exist in schema');
     assert.ok(props.departure_time_to, 'departure_time_to should exist in schema');
+  });
+});
+
+describe('MCP server — retired unlock_flight_offer', () => {
+  let proc: ChildProcessWithoutNullStreams;
+
+  before(() => { proc = spawnServer(); });
+  after(() => { proc.kill(); });
+
+  it('still answers the old name, pointing at book_flight', async () => {
+    // Delisted, but an agent holding an old tool list can still call it. It must
+    // get the replacement, not an error it has to interpret.
+    sendMessage(proc, { jsonrpc: '2.0', id: 1, method: 'initialize', params: {
+      protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '1' },
+    }});
+    await readNextMessage(proc);
+
+    sendMessage(proc, { jsonrpc: '2.0', id: 2, method: 'tools/call', params: {
+      name: 'unlock_flight_offer', arguments: { offer_id: 'off_1' },
+    }});
+    const response = await readNextMessage(proc);
+
+    const result = response.result as { content: Array<{ text: string }>; isError?: boolean };
+    assert.ok(!result.isError, 'the retired name is answered, not thrown');
+    const body = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    assert.equal(body.error, 'retired');
+    assert.equal(body.next, 'book_flight');
   });
 });
 

--- a/sdk/mcp/src/index.ts
+++ b/sdk/mcp/src/index.ts
@@ -279,7 +279,7 @@ async function openBookingQuestion(bookingRef: string): Promise<BookingQuestion 
         body: JSON.stringify({ intent: bookingRef }),
       });
       if (!resp.ok) continue;
-      d = (await resp.json()) as Record<string, unknown>;
+      d = await readJson(resp, `/api/booking-payment/${kind}`);
     } catch {
       // A question poll that fails must never turn a live booking status into an
       // error - the state we already have is still worth returning.


### PR DESCRIPTION
## Why

`TypeScript packages (Tier-1, required) (sdk/mcp)` has failed on every push to `main` since 4f1a0ba (2026-09-09). It's a **required** check, so every PR to `main` is blocked, including the Dependabot bumps #201–#203. The matrix's fail-fast also cancels `(sdk/js)` whenever `sdk/mcp` fails, so CI stopped proving the JS SDK too.

## The two failures

1. **`tools/list` › returns expected tools.** The test still required `unlock_flight_offer`, which 4f1a0ba **delisted on purpose** ("a tool in the list is a claim a model chooses from"). The test now checks the current contract:
   - the booking tools are listed: `get_flight_booking` and `answer_booking_question` are how a booking the package starts reaches its PNR, and gets answered when it pauses at a seat map, a paid extra or a price change;
   - `unlock_flight_offer` is **not** listed;
   - a new test calls the retired name and checks it still answers with the redirect to `book_flight`, which is the other half of that commit.
2. **dead-route guards › never a bare `resp.json()`.** `openBookingQuestion()` parsed the seat/extra poll with its own `await resp.json()`. It now goes through `readJson()` like every other call site. Behaviour is the same: a non-JSON body was caught and skipped before, and now reads as "no question open" and is skipped.

## Verification

- The unmodified code fails exactly CI's two tests, with the same messages (9/11 pass). With this change: **12/12**, `tsc --noEmit` clean.
- That ran on Windows, where the suite's `spawn('npx', …)` is ENOENT, so I used a local-only shim to start the server with `node --import tsx`. This PR's Linux CI is the real proof.
- The `Python deterministic tests` job in the same workflow will stay red for its older, known reason: the public repo ships tests for connectors that exist only in the private repo. It's not a required check.

No version bump: the published `letsfg-mcp` behaves the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYbE9AEZ2Kd9PvkxdUdtZu
