### PR TITLE
fix(sdk): `letsfg auth` requests the advertised scopes; a 401 carries the server's code (#212)

### DIFF
--- a/sdk/python/letsfg/__init__.py
+++ b/sdk/python/letsfg/__init__.py
@@ -44,7 +44,7 @@ from letsfg.models import (
 )
 from letsfg.models.flights import PublicFlightOffer, to_public_offer
 
-__version__ = "2026.5.98"
+__version__ = "2026.5.99"
 __all__ = [
     "LetsFG",
     "LetsFGError",

--- a/sdk/python/letsfg/connectors/auth.py
+++ b/sdk/python/letsfg/connectors/auth.py
@@ -59,7 +59,14 @@ _REFRESH_SKEW = 5 * 60
 # Must match client.py: Cloudflare blocks the urllib default UA with error 1010.
 _USER_AGENT = "LetsFG-Python-SDK/1.0.3"
 _CLIENT_NAME = "letsfg-python"
-_SCOPE = "flights"
+# The scopes the server advertises in `scopes_supported` (RFC 8414 discovery):
+# flights:search, flights:book, hotels:search, hotels:book, profile:read. The
+# CLI searches and books flights, nothing else. This used to be the bare word
+# "flights" (LetsFG/LetsFG#212): the server silently drops any scope it does
+# not know, so the consent succeeded and the grant carried NO scope at all --
+# every hosted-connector tool then refused it with "does not include
+# 'flights:search'". Keep every entry here one the server advertises.
+_SCOPE = "flights:search flights:book profile:read"
 
 
 class BearerTokenError(Exception):
@@ -242,7 +249,7 @@ _DONE_HTML = (
     b"<!doctype html><meta charset=utf-8>"
     b"<title>LetsFG connected</title>"
     b"<body style=\"font:16px system-ui;padding:3rem;text-align:center\">"
-    b"<h2>Card connected.</h2>"
+    b"<h2>Connected.</h2>"
     b"<p>You can close this tab and go back to the terminal.</p>"
 )
 _FAIL_HTML = (
@@ -392,10 +399,10 @@ def connect_auth(open_browser: bool = True) -> str:
             "scope": _SCOPE,
         })
 
-        print("\n  LetsFG needs a card connected before it can search or book.")
-        print("  Nothing is charged now - you pay the fare only when you book,")
-        print("  and it is held, not taken, until the airline confirms.\n")
-        print("  Open this and add a card (or pay 0.00 with Revolut Pay):\n")
+        print("\n  LetsFG needs you to approve this CLI once at letsfg.co/connect.")
+        print("  Nothing is charged now - a card is asked for at your first booking,")
+        print("  and the fare is held, not taken, until the airline confirms.\n")
+        print("  Open this and approve:\n")
         print(f"     {auth_url}\n")
         if open_browser:
             try:
@@ -431,7 +438,21 @@ def connect_auth(open_browser: bool = True) -> str:
             refresh_token=data.get("refresh_token"),
             client_id=str(client_id),
         )
-        print("done. Card connected - the token refreshes itself from now on.")
+        print("done. Connected - the token refreshes itself from now on.")
+        # RFC 6749 s3.3: when the granted scope differs from the requested one the
+        # server says so in `scope`. A grant that lost `flights:search` still
+        # searches through letsfg.co/api (that lane reads the card/account, not
+        # the scope) but every hosted-connector tool will refuse it -- say so
+        # here, once, instead of letting the next command fail on it.
+        granted = str(data.get("scope") or "").split() if "scope" in data else None
+        if granted is not None and "flights:search" not in granted:
+            print(
+                "\n  Warning: the grant came back without 'flights:search' "
+                f"(server granted: {' '.join(granted) or 'nothing'}).\n"
+                "  Searching via letsfg.co still works; the hosted connector at\n"
+                "  letsfg.co/developers/api/mcp will refuse this token. Run `letsfg auth`\n"
+                "  again and, if it repeats, report it at github.com/LetsFG/LetsFG/issues."
+            )
         return str(data["access_token"])
     finally:
         server.close()

--- a/sdk/python/letsfg/local.py
+++ b/sdk/python/letsfg/local.py
@@ -65,6 +65,32 @@ _WAIT_FOR_SPLIT = os.environ.get("LETSFG_WAIT_FOR_SPLIT", "").strip() != "0"
 _USER_AGENT = "LetsFG-Python-SDK/1.0.3"
 
 
+def _unauthorized(e: HTTPError) -> BearerTokenError:
+    """The message for a 401, carrying the server's own reason.
+
+    letsfg.co answers 401 with `{"error": "Unauthorized", "code": "NO_SESSION"}`
+    both when a token is expired or revoked AND when it was refused for another
+    reason -- for a week every OAuth token minted by a card-less `letsfg auth`
+    was refused that way (LetsFG/LetsFG#212), and this function's predecessor
+    called all of it "expired or revoked", which sent people back through the
+    consent flow three times for a bug on our side. Carry the code, so a report
+    can quote it and so a reconnect that does not help reads as what it is.
+    """
+    code = ""
+    try:
+        body = json.loads(e.read().decode(errors="replace"))
+        code = str(body.get("code") or body.get("error") or "").strip()
+    except Exception:
+        pass
+    detail = f" (server said: {code})" if code else ""
+    return BearerTokenError(
+        f"letsfg.co refused the Bearer token with HTTP 401{detail}.\n"
+        "  Run `letsfg auth` to reconnect. If a fresh connect is refused the same\n"
+        "  way, the token is being rejected server-side, not expired - please\n"
+        "  report it with the code above at github.com/LetsFG/LetsFG/issues."
+    )
+
+
 def _headers(token: str, *, json_body: bool = True) -> dict[str, str]:
     headers = {
         "Authorization": f"Bearer {token}",
@@ -131,9 +157,7 @@ async def search_local(
             result = json.loads(resp.read())
     except HTTPError as e:
         if e.code == 401:
-            raise BearerTokenError(
-                "Bearer token expired or revoked. Run `letsfg auth` to re-authenticate."
-            )
+            raise _unauthorized(e) from None
         raise
 
     search_id = result.get("search_id") or result.get("id")
@@ -229,9 +253,7 @@ async def book_offer(
             return json.loads(resp.read())
     except HTTPError as e:
         if e.code == 401:
-            raise BearerTokenError(
-                "Bearer token expired or revoked. Run `letsfg auth` to re-authenticate."
-            )
+            raise _unauthorized(e) from None
         raw = e.read().decode(errors="replace")
         try:
             return json.loads(raw)

--- a/sdk/python/letsfg/local.py
+++ b/sdk/python/letsfg/local.py
@@ -21,7 +21,7 @@ import os
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 
-from letsfg.connectors.auth import get_bearer_token, BearerTokenError
+from letsfg.connectors.auth import ensure_bearer_token, BearerTokenError
 
 _BASE_URL = os.environ.get("LETSFG_BASE_URL", "https://letsfg.co")
 # Poll fast and poll FIRST. The old loop slept 10s before its opening poll,
@@ -121,10 +121,15 @@ async def search_local(
     """
     Search flights via the LetsFG cloud API.
 
-    Requires a Bearer token — run `letsfg auth` once. Free and unlimited.
+    Requires a Bearer token — run `letsfg auth` once; it refreshes itself after that.
     Returns { offers: [...], total_results: N, search_id: "..." }.
     """
-    token = get_bearer_token()
+    # ensure_, not get_: the access token lasts an hour and the refresh token
+    # is stored right next to it. get_bearer_token() is synchronous and cannot
+    # refresh, so `letsfg search` an hour after `letsfg auth` told the person
+    # the token had expired and to run `letsfg auth` again (LetsFG/LetsFG#212
+    # went through the consent three times for less).
+    token = ensure_bearer_token()
 
     payload: dict = {
         "origin": origin,
@@ -231,7 +236,12 @@ async def book_offer(
     Retrying will not book it — hand the user `booking_url`, which goes straight
     to that exact offer. Nothing is charged in either case.
     """
-    token = get_bearer_token()
+    # ensure_, not get_: the access token lasts an hour and the refresh token
+    # is stored right next to it. get_bearer_token() is synchronous and cannot
+    # refresh, so `letsfg search` an hour after `letsfg auth` told the person
+    # the token had expired and to run `letsfg auth` again (LetsFG/LetsFG#212
+    # went through the consent three times for less).
+    token = ensure_bearer_token()
 
     payload: dict = {
         "search_id": search_id,

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "letsfg"
-version = "2026.5.98"
+version = "2026.5.99"
 description = "Flights and hotels for AI agents. Server-side engine covers hundreds of airlines; hotels are real bookable inventory with free cancellation and pay-later terms. Free flight search via Bearer token or prepaid Developer API."
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python/tests/test_connect_auth_scope.py
+++ b/sdk/python/tests/test_connect_auth_scope.py
@@ -1,0 +1,101 @@
+"""
+`letsfg auth` must request scopes the server advertises (LetsFG/LetsFG#212).
+
+The server's /oauth/authorize/init keeps only the requested scopes it knows
+(`scopes_supported` in RFC 8414 discovery) and drops the rest WITHOUT an error.
+The CLI used to send the bare word "flights", which is not one of them, so the
+consent succeeded and the grant carried no scope at all: every hosted-connector
+tool then answered "The connected OAuth grant does not include 'flights:search'".
+"""
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SDK_PYTHON_ROOT = PROJECT_ROOT / "sdk" / "python"
+if str(SDK_PYTHON_ROOT) not in sys.path:
+    sys.path.insert(0, str(SDK_PYTHON_ROOT))
+
+from letsfg.connectors import auth as A
+
+# What https://letsfg.co/developers/api/.well-known/oauth-authorization-server
+# publishes (api/services/oauth_store.py::ALL_SCOPES). Pinned here so a typo in
+# _SCOPE fails a test instead of a customer's consent.
+ADVERTISED = {"flights:search", "flights:book", "hotels:search", "hotels:book", "profile:read"}
+
+
+class _FakeCallbackServer:
+    def __init__(self, expected_state):
+        self.port = 43210
+
+    def wait_for_code(self, timeout=600):
+        return "code-1"
+
+    def close(self):
+        pass
+
+
+def _run_connect(token_response: dict) -> tuple[str, str]:
+    """Drive connect_auth() with every network edge stubbed; return (auth_url, stdout)."""
+    opened = []
+    saved = {}
+    out = io.StringIO()
+    with patch.object(A, "_discover", lambda: {
+                "authorization_endpoint": "https://letsfg.co/connect",
+                "token_endpoint": "https://letsfg.co/developers/api/oauth/token",
+                "registration_endpoint": "https://letsfg.co/developers/api/oauth/register",
+            }), \
+         patch.object(A, "_CallbackServer", _FakeCallbackServer), \
+         patch.object(A, "_post_json_abs", lambda url, payload, timeout=30: (201, {"client_id": "cid"})), \
+         patch.object(A, "_post_form", lambda url, fields, timeout=30: (200, token_response)), \
+         patch.object(A, "save_token", lambda *a, **k: saved.update(k)), \
+         patch.object(A.webbrowser, "open", lambda url: opened.append(url) or True), \
+         redirect_stdout(out):
+        A.connect_auth(open_browser=True)
+    assert opened, "connect_auth must open the authorize URL"
+    return opened[0], out.getvalue()
+
+
+class ScopeTest(unittest.TestCase):
+    def test_every_requested_scope_is_one_the_server_advertises(self):
+        requested = A._SCOPE.split()
+        self.assertTrue(requested, "must request at least one scope")
+        self.assertEqual(set(requested) - ADVERTISED, set(),
+                         "an unknown scope is dropped silently by the server")
+
+    def test_flights_search_is_requested(self):
+        # Without it, search_flights on the hosted connector refuses the grant.
+        self.assertIn("flights:search", A._SCOPE.split())
+        self.assertIn("flights:book", A._SCOPE.split())
+
+    def test_authorize_url_carries_the_scopes(self):
+        url, _ = _run_connect({"access_token": "at", "refresh_token": "rt", "expires_in": 3600,
+                               "scope": A._SCOPE})
+        q = parse_qs(urlparse(url).query)
+        self.assertEqual(q["scope"], [A._SCOPE])
+        self.assertEqual(q["response_type"], ["code"])
+        self.assertEqual(q["code_challenge_method"], ["S256"])
+
+    def test_a_scopeless_grant_is_reported_not_swallowed(self):
+        # RFC 6749 s3.3: the server reports the scope it actually granted.
+        _, out = _run_connect({"access_token": "at", "refresh_token": "rt", "expires_in": 3600,
+                               "scope": ""})
+        self.assertIn("flights:search", out)
+        self.assertIn("Warning", out)
+
+    def test_a_full_grant_prints_no_warning(self):
+        _, out = _run_connect({"access_token": "at", "refresh_token": "rt", "expires_in": 3600,
+                               "scope": A._SCOPE})
+        self.assertNotIn("Warning", out)
+
+    def test_a_server_that_omits_scope_is_not_accused(self):
+        _, out = _run_connect({"access_token": "at", "refresh_token": "rt", "expires_in": 3600})
+        self.assertNotIn("Warning", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/test_search_unauthorized.py
+++ b/sdk/python/tests/test_search_unauthorized.py
@@ -1,0 +1,72 @@
+"""
+A 401 from letsfg.co carries the server's own code (LetsFG/LetsFG#212).
+
+letsfg.co answers `401 {"error":"Unauthorized","code":"NO_SESSION"}` for an
+expired token and for a token it refused for any other reason. The old message
+called every 401 "Bearer token expired or revoked", which sent a person through
+the consent flow three times for a bug on our side. The code must reach the
+message so a report can quote it.
+"""
+import asyncio
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SDK_PYTHON_ROOT = PROJECT_ROOT / "sdk" / "python"
+if str(SDK_PYTHON_ROOT) not in sys.path:
+    sys.path.insert(0, str(SDK_PYTHON_ROOT))
+
+from letsfg import local as L
+from letsfg.connectors.auth import BearerTokenError
+
+
+def _http_error(status: int, body: bytes) -> HTTPError:
+    return HTTPError("https://letsfg.co/api/search", status, "Unauthorized", {}, io.BytesIO(body))
+
+
+class UnauthorizedMessageTest(unittest.TestCase):
+    def _search(self, err: HTTPError) -> str:
+        def raise_it(req, timeout=30):
+            raise err
+        with patch.object(L, "get_bearer_token", lambda: "lfg_at_x"), \
+             patch.object(L, "urlopen", raise_it):
+            with self.assertRaises(BearerTokenError) as cm:
+                asyncio.run(L.search_local("LUX", "LCY", "2026-10-01"))
+        return str(cm.exception)
+
+    def test_search_carries_the_servers_code(self):
+        msg = self._search(_http_error(401, b'{"error":"Unauthorized","code":"NO_SESSION"}'))
+        self.assertIn("401", msg)
+        self.assertIn("NO_SESSION", msg)
+        self.assertIn("letsfg auth", msg)
+        self.assertNotIn("expired or revoked", msg, "a refused token is not necessarily expired")
+
+    def test_a_401_without_a_body_still_points_at_letsfg_auth(self):
+        msg = self._search(_http_error(401, b"nope"))
+        self.assertIn("401", msg)
+        self.assertIn("letsfg auth", msg)
+
+    def test_book_uses_the_same_message(self):
+        def raise_it(req, timeout=60):
+            raise _http_error(401, b'{"error":"Unauthorized","code":"NO_SESSION"}')
+        with patch.object(L, "get_bearer_token", lambda: "lfg_at_x"), \
+             patch.object(L, "urlopen", raise_it):
+            with self.assertRaises(BearerTokenError) as cm:
+                asyncio.run(L.book_offer("s1", "o1", {"given_name": "A"}, "a@example.com"))
+        self.assertIn("NO_SESSION", str(cm.exception))
+
+    def test_other_errors_are_not_rewritten(self):
+        def raise_it(req, timeout=30):
+            raise _http_error(500, b"boom")
+        with patch.object(L, "get_bearer_token", lambda: "lfg_at_x"), \
+             patch.object(L, "urlopen", raise_it):
+            with self.assertRaises(HTTPError):
+                asyncio.run(L.search_local("LUX", "LCY", "2026-10-01"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/test_search_unauthorized.py
+++ b/sdk/python/tests/test_search_unauthorized.py
@@ -28,11 +28,31 @@ def _http_error(status: int, body: bytes) -> HTTPError:
     return HTTPError("https://letsfg.co/api/search", status, "Unauthorized", {}, io.BytesIO(body))
 
 
+class TokenRefreshTest(unittest.TestCase):
+    def test_search_refreshes_an_expired_token_instead_of_asking_for_letsfg_auth(self):
+        # An hour after `letsfg auth` the access token is stale but the refresh
+        # token is stored next to it; search_local must go through the refresher.
+        import time
+        from letsfg.connectors import auth as A
+        stored = {"pfs_auth": {"token": "stale", "expires_at": time.time() - 10,
+                               "refresh_token": "rt", "client_id": "cid"}}
+        refreshed = []
+        def refused(req, timeout=30):
+            raise _http_error(401, b'{"code":"NO_SESSION"}')
+
+        with (patch.object(A, "_load_config", lambda: stored),
+              patch.object(A, "refresh_access_token", lambda: refreshed.append(1) or "fresh"),
+              patch.object(L, "urlopen", refused)):
+            with self.assertRaises(BearerTokenError):
+                asyncio.run(L.search_local("LUX", "LCY", "2026-10-01"))
+        self.assertEqual(refreshed, [1], "the stale token must be refreshed, not reported as expired")
+
+
 class UnauthorizedMessageTest(unittest.TestCase):
     def _search(self, err: HTTPError) -> str:
         def raise_it(req, timeout=30):
             raise err
-        with patch.object(L, "get_bearer_token", lambda: "lfg_at_x"), \
+        with patch.object(L, "ensure_bearer_token", lambda: "lfg_at_x"), \
              patch.object(L, "urlopen", raise_it):
             with self.assertRaises(BearerTokenError) as cm:
                 asyncio.run(L.search_local("LUX", "LCY", "2026-10-01"))
@@ -53,7 +73,7 @@ class UnauthorizedMessageTest(unittest.TestCase):
     def test_book_uses_the_same_message(self):
         def raise_it(req, timeout=60):
             raise _http_error(401, b'{"error":"Unauthorized","code":"NO_SESSION"}')
-        with patch.object(L, "get_bearer_token", lambda: "lfg_at_x"), \
+        with patch.object(L, "ensure_bearer_token", lambda: "lfg_at_x"), \
              patch.object(L, "urlopen", raise_it):
             with self.assertRaises(BearerTokenError) as cm:
                 asyncio.run(L.book_offer("s1", "o1", {"given_name": "A"}, "a@example.com"))
@@ -62,7 +82,7 @@ class UnauthorizedMessageTest(unittest.TestCase):
     def test_other_errors_are_not_rewritten(self):
         def raise_it(req, timeout=30):
             raise _http_error(500, b"boom")
-        with patch.object(L, "get_bearer_token", lambda: "lfg_at_x"), \
+        with patch.object(L, "ensure_bearer_token", lambda: "lfg_at_x"), \
              patch.object(L, "urlopen", raise_it):
             with self.assertRaises(HTTPError):
                 asyncio.run(L.search_local("LUX", "LCY", "2026-10-01"))


### PR DESCRIPTION
Fixes #212 (CLI half). Version 2026.5.99.

**1. Scope.** The consent requested `scope=flights`, which the server does not advertise. The server keeps only the scopes it knows and drops the rest without an error, so the consent succeeded and the grant carried no scope at all; every hosted-connector tool then answered *"does not include 'flights:search'"*. The CLI now requests `flights:search flights:book profile:read` (each in `scopes_supported`) and reads the `scope` the token response reports back: a grant that lost `flights:search` prints a warning at `letsfg auth` instead of failing on the next command.

**2. The 401.** `letsfg search` reported every 401 as *"Bearer token expired or revoked"*. letsfg.co answers `401 {"code":"NO_SESSION"}` for an expired token and for a token it refused for any other reason, which is what happened here: the site's OAuth-grant bridge did not resolve the card-less grants the 2026-09-09 connect issues. That is fixed server-side (private repo, deploying). The CLI now carries the server's code and says a reconnect refused the same way is a server-side rejection to report, not an expired token.

**3. Refresh.** `letsfg search` and `letsfg book` used the synchronous token getter, so an hour after `letsfg auth` they asked for `letsfg auth` again although the 30-day refresh token was stored. Both now refresh silently.

`letsfg search` stays on `POST /api/search`: that is the CLI's lane and the token it holds is accepted there once the server fix is live. The hosted connector's tool payloads are shaped for a model, not for the CLI's table.

**Verified live (2026-09-11):** the fixed CLI's consent stored a grant with `scope = flights:search flights:book profile:read`, and the token was accepted by the hosted connector (`get_preferences` returned a result). `POST /api/search` with the same token answered `401 NO_SESSION` before the website fix was deployed.

Tests: `tests/test_connect_auth_scope.py`, `tests/test_search_unauthorized.py`. The required "Python deterministic tests" check is red on this PR and identically red on `main` (17 pre-existing collection errors from tests importing private-repo connectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUAYEJYyGDsASY2nxLWg7G
