### PR TITLE
fix(cli): render the offers the API returns, send the options the API reads, say what booking answered

### DIFF
--- a/sdk/python/letsfg/__init__.py
+++ b/sdk/python/letsfg/__init__.py
@@ -45,7 +45,7 @@ from letsfg.models import (
 )
 from letsfg.models.flights import PublicFlightOffer, to_public_offer
 
-__version__ = "2026.5.99"
+__version__ = "2026.5.100"
 __all__ = [
     "LetsFG",
     "LetsFGError",

--- a/sdk/python/letsfg/cli.py
+++ b/sdk/python/letsfg/cli.py
@@ -49,7 +49,11 @@ app = typer.Typer(
     ),
     no_args_is_help=True,
 )
-console = Console() if HAS_RICH else None
+# A pipe or file has no width, and rich then folds the table into 80 columns -
+# `LTN→…` for a route, `FR-R…` for an airline - which is what every agent
+# capturing this CLI would read. Give a redirected stream room; a console keeps
+# its real width.
+console = Console(width=None if sys.stdout.isatty() else 160) if HAS_RICH else None
 
 
 def _get_client(api_key: str | None = None, base_url: str | None = None) -> LetsFG:
@@ -271,14 +275,65 @@ def _offer_price(offer: dict) -> float:
 
 
 def _offer_duration_seconds(offer: dict) -> int:
-    """Extract comparable offer duration; missing/invalid values sort last."""
-    raw = offer.get("duration_seconds")
-    if raw is None:
-        raw = (offer.get("outbound") or {}).get("total_duration_seconds")
+    """Comparable trip duration (outbound + inbound); missing values sort last."""
+    total = 0
+    for leg in (offer, offer.get("inbound")):
+        if not leg:
+            continue
+        try:
+            total += int(leg.get("duration_minutes") or 0) * 60
+        except (TypeError, ValueError):
+            pass
+    return total or int(1e18)
+
+
+def _leg_airlines(leg: dict) -> str:
+    """Airline column for one leg: 'W6-Wizz Air', or 'W6-Wizz Air + FR-Ryanair'
+    when the segments are flown by different carriers."""
+    if not leg:
+        return "-"
+    seen: list[tuple[str, str]] = []
+    for s in leg.get("segments") or []:
+        key = (str(s.get("airline_code") or ""), str(s.get("airline") or ""))
+        if any(key[0] or key[1]) and key not in seen:
+            seen.append(key)
+    if not seen:
+        seen = [(str(leg.get("airline_code") or ""), str(leg.get("airline") or ""))]
+    parts = [_fmt_airline(code or name, [name]) for code, name in seen if code or name]
+    return " + ".join(parts) or "-"
+
+
+def _leg_route(leg: dict) -> str:
+    """'WAW→BGY→BCN' from the segments, or 'WAW→BCN' from the leg itself."""
+    if not leg:
+        return "-"
+    segs = leg.get("segments") or []
+    codes = [segs[0].get("origin", "")] + [s.get("destination", "") for s in segs] if segs \
+        else [leg.get("origin", ""), leg.get("destination", "")]
+    route = "→".join(c for c in codes if c)
+    return route or "-"
+
+
+def _leg_duration(leg: dict) -> str:
+    if not leg:
+        return "-"
     try:
-        return int(raw) if raw is not None else int(1e18)
+        minutes = int(leg.get("duration_minutes") or 0)
     except (TypeError, ValueError):
-        return int(1e18)
+        return "-"
+    if not minutes:
+        return "-"
+    h, m = divmod(minutes, 60)
+    return f"{h}h {m:02d}m"
+
+
+def _leg_stops(leg: dict) -> str:
+    if not leg:
+        return "-"
+    stops = leg.get("stops")
+    if stops is None:
+        stops = max(len(leg.get("segments") or []) - 1, 0)
+    return str(stops)
 
 
 def _final_sort_offers(offers: list[dict], sort: str) -> None:
@@ -295,13 +350,10 @@ def _format_leg_time(leg: dict, pos: str = "dep", include_day_offset: bool = Fal
         return "-"
 
     segs = leg.get("segments") or []
-    if not segs:
-        return "-"
-
     if pos == "dep":
-        dt_str = segs[0].get("departure", "")
+        dt_str = leg.get("departure_time") or (segs[0].get("departure_time", "") if segs else "")
     else:
-        dt_str = segs[-1].get("arrival", "")
+        dt_str = leg.get("arrival_time") or (segs[-1].get("arrival_time", "") if segs else "")
 
     if not dt_str:
         return "-"
@@ -314,7 +366,7 @@ def _format_leg_time(leg: dict, pos: str = "dep", include_day_offset: bool = Fal
     if pos != "arr" or not include_day_offset:
         return time_part
 
-    dep_str = segs[0].get("departure", "")
+    dep_str = leg.get("departure_time") or (segs[0].get("departure_time", "") if segs else "")
     if not dep_str or "T" not in dep_str or "T" not in dt_str:
         return time_part
 
@@ -423,27 +475,8 @@ def search(
     if search_id:
         print(f"  search_id: {search_id}  (needed for `letsfg book`, offers expire ~15 min after search)")
 
-    def _route_str(leg):
-        if not leg:
-            return "-"
-        route = leg.get("route_str", "")
-        if not route:
-            segs = leg.get("segments", [])
-            if segs:
-                codes = [segs[0].get("origin", "")]
-                for s in segs:
-                    codes.append(s.get("destination", ""))
-                route = "→".join(c for c in codes if c)
-        return route or "-"
-
-    def _dur_str(leg):
-        if not leg:
-            return "-"
-        dur_s = leg.get("total_duration_seconds")
-        if dur_s:
-            h, m = divmod(dur_s // 60, 60)
-            return f"{h}h {m:02d}m"
-        return "-"
+    _route_str = _leg_route
+    _dur_str = _leg_duration
 
     def _time_str(leg, pos="dep"):
         return _format_leg_time(leg, pos=pos, include_day_offset=(pos == "arr"))
@@ -466,10 +499,10 @@ def search(
             table.add_column("Dur", justify="right")
 
         for i, o in enumerate(offers, 1):
-            ob = o.get("outbound", {})
+            ob = o            # the outbound leg IS the offer
             ib = o.get("inbound")
-            airlines = _fmt_airline(o.get("owner_airline", ""), o.get("airlines", []))
-            stops = str(ob.get("stopovers", 0))
+            airlines = _leg_airlines(ob)
+            stops = _leg_stops(ob)
             raw_price = o.get("price", 0)
             raw_currency = (o.get("currency", currency) or currency).upper()
             price, cur = _convert_display_price(raw_price, raw_currency, target_currency, eur_rates)
@@ -490,6 +523,7 @@ def search(
             id_str = f"  [{offer_id}]" if offer_id else ""
             unlock = o.get("unlock_url", "")
             pt = o.get("payment_token", "")
+            airlines = _leg_airlines(o)
             print(f"  {i:3d}. {cur} {price:.2f} {airlines}{id_str}")
             if unlock:
                 print(f"       Unlock: {unlock}")
@@ -500,8 +534,8 @@ def search(
             raw_price = o.get("price", 0)
             raw_currency = (o.get("currency", currency) or currency).upper()
             price, cur = _convert_display_price(raw_price, raw_currency, target_currency, eur_rates)
-            airlines = _fmt_airline(o.get("owner_airline", ""), o.get("airlines", []))
-            ob = o.get("outbound", {})
+            airlines = _leg_airlines(o)
+            ob = o
             ib = o.get("inbound")
             dep = _time_str(ob, "dep")
             arr = _time_str(ob, "arr")
@@ -578,7 +612,12 @@ def unlock(
 def book(
     offer_id: str = typer.Argument(..., help="Offer ID from `letsfg search`"),
     search_id: Optional[str] = typer.Option(None, "--search-id", help="search_id from `letsfg search` (required unless --api-key is set, i.e. the paid Developer API flow)"),
-    passenger: list[str] = typer.Option(..., "--passenger", "-p", help='JSON passenger object: \'{"given_name":"John","family_name":"Doe","born_on":"1990-01-15","gender":"m","phone_number":"+15551234567"}\''),
+    passenger: list[str] = typer.Option(..., "--passenger", "-p", help=(
+        "JSON traveller object. The airline's checkout needs: given_name, family_name, born_on "
+        "(YYYY-MM-DD), gender (m/f), nationality (ISO 2), phone_number + phone_country, "
+        "address_line1, address_city, address_postal, address_country; passport is optional. "
+        "Anything missing comes back as missing_fields and nothing is charged."
+    )),
     email: str = typer.Option(..., "--email", "-e", help="Contact email"),
     phone: str = typer.Option("", "--phone", help="Contact phone (used if not already in the passenger JSON)"),
     output_json: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
@@ -628,13 +667,7 @@ def book(
             _json_out(result)
             return
 
-        if result.get("booked"):
-            print(f"\n  ✓ Booking confirmed!")
-            print(f"    Order ID: {result.get('order_id')}")
-            print(f"    Charged: {result.get('charged', 0)} {result.get('currency', '')}\n")
-        else:
-            print(f"\n  Could not complete a confirmed booking. Nothing was charged.")
-            print(f"    Booking link: {result.get('booking_url', '(none)')}\n")
+        _print_book_result(result)
         return
 
     bt = _get_client(api_key, base_url)
@@ -680,6 +713,98 @@ def book(
         _err(f"Booking failed: {result.details}")
 
 
+def _print_book_result(result: dict) -> None:
+    """Human output for POST /api/agent-book.
+
+    The route answers one of: `{booking_ref}` (the fare is held and a booking
+    agent is buying the ticket - poll it), `missing_details` + `missing_fields`
+    (nothing charged), `payment_method_required` + `add_card_url` (nothing
+    charged), or another `error` with a `message`. The previous output printed
+    "Could not complete a confirmed booking ... Booking link: (none)" for every
+    one of the last three, hiding the field list and the add-card link that
+    told the person what to do next.
+    """
+    ref = result.get("booking_ref")
+    if ref:
+        print("\n  Booking started. The fare is held on the connected card - it is captured")
+        print("  only once the airline confirms with a PNR (usually 4-11 minutes).")
+        print(f"    booking_ref: {ref}")
+        print(f"    Check on it:  letsfg booking {ref}   (add --wait to poll until it settles)\n")
+        return
+    err = str(result.get("error") or "")
+    msg = str(result.get("message") or "")
+    if err == "missing_details":
+        fields = result.get("missing_fields") or []
+        print("\n  Not booked yet - the traveller's details are incomplete. Nothing was charged.")
+        print(f"    Missing: {', '.join(str(f) for f in fields) or '(unspecified)'}")
+        print("    Add them to the --passenger JSON and run the same command again.\n")
+        return
+    if err in ("payment_method_required", "payment_declined"):
+        print("\n  Not booked - this account has no usable payment method. Nothing was charged.")
+        if msg:
+            print(f"    {msg}")
+        url = result.get("add_card_url")
+        if url:
+            print(f"    Add a card here, then run the same command again: {url}")
+        print()
+        return
+    print("\n  Not booked. Nothing was charged.")
+    if err:
+        print(f"    error: {err}")
+    if msg:
+        print(f"    {msg}")
+    print()
+
+
+@app.command()
+def booking(
+    booking_ref: str = typer.Argument(..., help="booking_ref returned by `letsfg book`"),
+    wait: bool = typer.Option(False, "--wait", "-w", help="Poll every 20 s until the booking completes or fails (up to 20 min)"),
+    output_json: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+):
+    """Check a booking started by `letsfg book`. Free; requires `letsfg auth`."""
+    import time
+    from letsfg.local import booking_status
+    from letsfg.connectors.auth import BearerTokenError
+
+    terminal = {"completed", "failed", "needs_attention"}
+    deadline = time.time() + 20 * 60
+    result: dict = {}
+    while True:
+        try:
+            result = asyncio.run(booking_status(booking_ref))
+        except BearerTokenError as e:
+            _err(str(e))
+        except Exception as e:
+            _err(f"Could not read the booking status: {e}")
+        state = str(result.get("state") or "")
+        if not wait or state in terminal or time.time() > deadline:
+            break
+        if not output_json:
+            print(f"  {state or 'no record yet'} ... polling again in 20 s", flush=True)
+        time.sleep(20)
+
+    if output_json:
+        _json_out(result)
+        return
+    if result.get("error"):
+        _err(f"{result.get('error')}: {result.get('message') or ''}".strip())
+    state = str(result.get("state") or "")
+    if state == "completed":
+        print(f"\n  ✓ Booked. PNR: {result.get('pnr')}")
+        print(f"    Charged: {result.get('charged_amount')} {result.get('currency') or ''}\n")
+    elif state == "failed":
+        print("\n  Booking failed - the hold was released, nothing was charged.")
+        print(f"    Reason: {result.get('failure_reason') or result.get('decline_reason') or '(none given)'}\n")
+    elif state == "needs_attention":
+        print("\n  A person at LetsFG is checking this booking. Do not book it again.")
+        print(f"    Reason: {result.get('failure_reason') or '(none given)'}\n")
+    elif state:
+        print(f"\n  {state} - still in progress. Check again in 20-30 s (or use --wait).\n")
+    else:
+        print(f"\n  No booking record yet. {result.get('message') or 'Check again in 20-30 s.'}\n")
+
+
 # ── Locations ─────────────────────────────────────────────────────────────
 
 @app.command()
@@ -689,7 +814,17 @@ def locations(
     api_key: Optional[str] = typer.Option(None, "--api-key", "-k", envvar="LETSFG_API_KEY"),
     base_url: Optional[str] = typer.Option(None, "--base-url", envvar="LETSFG_BASE_URL"),
 ):
-    """Resolve city/airport name to IATA codes."""
+    """Resolve city/airport name to IATA codes (Developer API key required; search itself takes IATA codes)."""
+    from letsfg.client import _saved_api_key
+
+    if not (api_key or os.environ.get("LETSFG_API_KEY") or _saved_api_key()):
+        # Without a key the Developer API answers 401, which used to be swallowed
+        # into "No locations found for 'London'" - as if London did not exist.
+        _err(
+            "`letsfg locations` uses the paid Developer API and needs an API key "
+            "(--api-key or LETSFG_API_KEY).\n"
+            "  `letsfg search` needs no key: give it IATA codes directly, e.g. LON, LHR, NYC, BCN."
+        )
     bt = _get_client(api_key, base_url)
     try:
         result = _resolve_locations_with_local_fallback(bt, query)
@@ -945,7 +1080,22 @@ def me(
 
 
 
+def _utf8_streams() -> None:
+    """Redirected stdout/stderr on Windows use the locale code page (cp1252),
+    which cannot encode the arrows in the results table, so
+    `letsfg search ... > out.txt` -- and every agent capturing this CLI through
+    a pipe -- died with UnicodeEncodeError after the search had already run. A
+    console is UTF-8 already; a pipe or file is switched to it here."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            if not stream.isatty():
+                stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+
 def main():
+    _utf8_streams()
     app()
 
 

--- a/sdk/python/letsfg/local.py
+++ b/sdk/python/letsfg/local.py
@@ -138,18 +138,22 @@ async def search_local(
         "adults": adults,
         "children": children,
         "currency": currency,
-        "limit": limit,
     }
     if return_date:
         payload["return_date"] = return_date
+    # Key names are the website route's (website/app/api/search/route.ts reads
+    # `max_stops`, `cabin`, `sort_by`). This used to send `max_stopovers`,
+    # `cabin_class` and `sort`, none of which the route reads, so `--direct`,
+    # `--cabin` and `--sort` were accepted by the CLI and silently ignored by
+    # the server -- a "direct only" search came back with every connection.
     if cabin_class:
-        payload["cabin_class"] = cabin_class
+        payload["cabin"] = cabin_class
     if infants:
         payload["infants"] = infants
     if max_stopovers is not None:
-        payload["max_stopovers"] = max_stopovers
+        payload["max_stops"] = max_stopovers
     if sort:
-        payload["sort"] = sort
+        payload["sort_by"] = sort
 
     req = Request(
         f"{_BASE_URL}/api/search",
@@ -269,6 +273,35 @@ async def book_offer(
             return json.loads(raw)
         except Exception:
             return {"ok": False, "booked": False, "error": raw[:400]}
+
+
+async def booking_status(booking_ref: str) -> dict:
+    """
+    One poll of POST /api/agent-book/status for a booking started by book_offer().
+
+    Returns the server's record: `state` (booking_in_progress / completed /
+    failed / needs_attention, '' while no record exists yet), `pnr`,
+    `charged_amount` (the CAPTURED amount - null until capture), `currency`,
+    `failure_reason`, `decline_reason`, `updated_at_ms`.
+    """
+    token = ensure_bearer_token()
+    req = Request(
+        f"{_BASE_URL}/api/agent-book/status",
+        data=json.dumps({"booking_ref": booking_ref}).encode(),
+        headers=_headers(token),
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+    except HTTPError as e:
+        if e.code == 401:
+            raise _unauthorized(e) from None
+        raw = e.read().decode(errors="replace")
+        try:
+            return json.loads(raw)
+        except Exception:
+            return {"error": raw[:400]}
 
 
 async def _resolve_location_local(query: str) -> list[dict]:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "letsfg"
-version = "2026.5.99"
+version = "2026.5.100"
 description = "Flights and hotels for AI agents. Server-side engine covers hundreds of airlines; hotels are real bookable inventory with free cancellation and pay-later terms. Free flight search via Bearer token or prepaid Developer API."
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python/tests/test_cli_offer_shape.py
+++ b/sdk/python/tests/test_cli_offer_shape.py
@@ -1,0 +1,244 @@
+"""
+The CLI renders the offer shape /api/results actually returns, sends the body
+keys /api/search actually reads, and says what /api/agent-book actually answered.
+
+Driven live on 2026-09-11 (LetsFG/LetsFG#212 follow-up): every table cell but
+the price was "-", `--direct` came back with every connection, and a
+`missing_details` answer printed "Could not complete a confirmed booking ...
+Booking link: (none)". The fixtures below are trimmed copies of real responses
+from that run (search ws_0643b31599384f05, WAW-BCN round trip).
+"""
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SDK_PYTHON_ROOT = PROJECT_ROOT / "sdk" / "python"
+if str(SDK_PYTHON_ROOT) not in sys.path:
+    sys.path.insert(0, str(SDK_PYTHON_ROOT))
+
+from typer.testing import CliRunner
+
+from letsfg import cli
+from letsfg import local as L
+
+# One real round-trip offer, as /api/results returns it: the outbound leg IS the
+# offer, and the return leg is `inbound` with the same fields.
+RT_OFFER = {
+    "id": "wo_f041c49a12cc", "price": 91.14, "currency": "EUR", "source": "kayak_meta",
+    "airline": "Wizz Air", "airline_code": "W6", "origin": "WAW", "destination": "BCN",
+    "departure_time": "2026-10-20T18:00:00", "arrival_time": "2026-10-20T22:55:00",
+    "duration_minutes": 295, "stops": 1, "flight_number": "W61433",
+    "segments": [
+        {"airline": "Wizz Air", "airline_code": "W6", "flight_number": "W61433", "origin": "WAW",
+         "destination": "BGY", "departure_time": "2026-10-20T18:00:00", "arrival_time": "2026-10-20T20:05:00",
+         "duration_minutes": 125, "cabin": "M"},
+        {"airline": "Ryanair", "airline_code": "FR", "flight_number": "FR3319", "origin": "BGY",
+         "destination": "BCN", "departure_time": "2026-10-20T21:15:00", "arrival_time": "2026-10-20T22:55:00",
+         "duration_minutes": 100, "cabin": "M"},
+    ],
+    "inbound": {
+        "origin": "BCN", "destination": "WAW", "departure_time": "2026-10-27T19:00:00",
+        "arrival_time": "2026-10-27T22:10:00", "duration_minutes": 190, "stops": 0,
+        "airline": "Wizz Air", "airline_code": "W6", "flight_number": "W61478",
+        "segments": [{"airline": "Wizz Air", "airline_code": "W6", "flight_number": "W61478", "origin": "BCN",
+                      "destination": "WAW", "departure_time": "2026-10-27T19:00:00",
+                      "arrival_time": "2026-10-27T22:10:00", "duration_minutes": 190, "cabin": "M"}],
+    },
+}
+# A one-way offer that lands after midnight.
+OW_OFFER = {
+    "id": "wo_ab3fbcde6d41", "price": 17.44, "currency": "EUR", "airline": "Ryanair", "airline_code": "FR",
+    "origin": "LTN", "destination": "BCN", "departure_time": "2026-10-20T23:45:00",
+    "arrival_time": "2026-10-21T02:55:00", "duration_minutes": 130, "stops": 0,
+    "segments": [{"airline": "Ryanair", "airline_code": "FR", "origin": "LTN", "destination": "BCN",
+                  "departure_time": "2026-10-20T23:45:00", "arrival_time": "2026-10-21T02:55:00",
+                  "duration_minutes": 130}],
+}
+
+runner = CliRunner()
+
+
+def _search_returning(offers):
+    async def fake(*a, **k):
+        return {"offers": list(offers), "total_results": len(offers), "search_id": "ws_test"}
+    return fake
+
+
+class RenderTest(unittest.TestCase):
+    def _run(self, offers, *args):
+        with patch.object(L, "search_local", _search_returning(offers)), \
+             patch.object(cli, "HAS_RICH", False):
+            r = runner.invoke(cli.app, ["search", "WAW", "BCN", "2026-10-20", *args])
+        self.assertEqual(r.exit_code, 0, r.output)
+        return r.output
+
+    def test_round_trip_row_shows_airlines_route_times_and_return(self):
+        out = self._run([RT_OFFER], "--return", "2026-10-27")
+        self.assertIn("EUR 91.14", out)
+        self.assertIn("W6-Wizz Air + FR-Ryanair", out, "both carriers of a two-segment leg")
+        self.assertIn("WAW→BGY→BCN", out)
+        self.assertIn("18:00→22:55", out)
+        self.assertIn("ret: BCN→WAW", out)
+        self.assertNotIn(" -  ", out.split("Offer IDs")[0] if "Offer IDs" in out else out)
+
+    def test_leg_helpers_read_the_flat_shape(self):
+        self.assertEqual(cli._leg_route(RT_OFFER), "WAW→BGY→BCN")
+        self.assertEqual(cli._leg_duration(RT_OFFER), "4h 55m")
+        self.assertEqual(cli._leg_stops(RT_OFFER), "1")
+        self.assertEqual(cli._leg_stops(RT_OFFER["inbound"]), "0")
+        self.assertEqual(cli._leg_airlines(RT_OFFER["inbound"]), "W6-Wizz Air")
+        self.assertEqual(cli._format_leg_time(RT_OFFER, "dep"), "18:00")
+        self.assertEqual(cli._format_leg_time(RT_OFFER["inbound"], "arr", include_day_offset=True), "22:10")
+
+    def test_arrival_after_midnight_carries_a_day_offset(self):
+        self.assertEqual(cli._format_leg_time(OW_OFFER, "arr", include_day_offset=True), "02:55+1")
+
+    def test_duration_sort_uses_both_legs(self):
+        self.assertEqual(cli._offer_duration_seconds(RT_OFFER), (295 + 190) * 60)
+        self.assertEqual(cli._offer_duration_seconds(OW_OFFER), 130 * 60)
+
+    def test_rich_table_renders_the_same_fields(self):
+        if not cli.HAS_RICH:
+            self.skipTest("rich not installed")
+        with patch.object(L, "search_local", _search_returning([RT_OFFER])):
+            # CliRunner's stdout is not a tty, like a pipe: the table must not fold to 80 columns.
+            r = runner.invoke(cli.app, ["search", "WAW", "BCN", "2026-10-20", "--return", "2026-10-27"])
+        self.assertEqual(r.exit_code, 0, r.output)
+        for needle in ("Wizz Air", "WAW→BGY→BCN", "18:00", "22:55", "4h 55m", "BCN→WAW", "3h 10m"):
+            self.assertIn(needle, r.output)
+
+
+class SearchBodyTest(unittest.TestCase):
+    def test_sends_the_keys_the_website_route_reads(self):
+        import asyncio
+        seen = {}
+
+        class _Resp:
+            status = 200
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return json.dumps({"offers": [], "total_results": 0}).encode()
+
+        def fake_urlopen(req, timeout=30):
+            seen["body"] = json.loads(req.data.decode())
+            return _Resp()
+
+        with patch.object(L, "ensure_bearer_token", lambda: "t"), patch.object(L, "urlopen", fake_urlopen):
+            asyncio.run(L.search_local("WAW", "BCN", "2026-10-20", return_date="2026-10-27",
+                                       cabin_class="C", max_stopovers=0, sort="duration", limit=20))
+        b = seen["body"]
+        self.assertEqual(b["max_stops"], 0, "--direct must reach the server as max_stops")
+        self.assertEqual(b["cabin"], "C")
+        self.assertEqual(b["sort_by"], "duration")
+        self.assertEqual(b["return_date"], "2026-10-27")
+        for stale in ("max_stopovers", "cabin_class", "sort", "limit"):
+            self.assertNotIn(stale, b, f"{stale} is not a key the route reads")
+
+
+class BookOutputTest(unittest.TestCase):
+    def _book(self, answer):
+        async def fake(**k):
+            return answer
+        with patch.object(L, "book_offer", fake), patch.object(cli, "HAS_RICH", False), \
+             patch.dict("os.environ", {"LETSFG_API_KEY": ""}), \
+             patch("letsfg.client._saved_api_key", lambda: None):
+            r = runner.invoke(cli.app, ["book", "wo_1", "--search-id", "ws_1", "--email", "t@example.com",
+                                        "--passenger", '{"given_name":"T"}'])
+        return r
+
+    def test_missing_details_lists_the_fields(self):
+        r = self._book({"error": "missing_details", "missing_fields": ["address_city", "phone_country"], "charged": 0})
+        self.assertEqual(r.exit_code, 0, r.output)
+        self.assertIn("address_city, phone_country", r.output)
+        self.assertIn("Nothing was charged", r.output)
+        self.assertNotIn("Booking link", r.output)
+
+    def test_payment_method_required_shows_the_add_card_link(self):
+        r = self._book({"error": "payment_method_required", "message": "No card.", "add_card_url": "https://letsfg.co/connect?card=abc"})
+        self.assertEqual(r.exit_code, 0, r.output)
+        self.assertIn("https://letsfg.co/connect?card=abc", r.output)
+        self.assertIn("Nothing was charged", r.output)
+
+    def test_a_started_booking_hands_over_the_ref_and_the_poll_command(self):
+        r = self._book({"booking_ref": "bk_123"})
+        self.assertEqual(r.exit_code, 0, r.output)
+        self.assertIn("bk_123", r.output)
+        self.assertIn("letsfg booking bk_123", r.output)
+
+
+class BookingStatusTest(unittest.TestCase):
+    def _status(self, answer, *args):
+        async def fake(ref):
+            return answer
+        with patch.object(L, "booking_status", fake), patch.object(cli, "HAS_RICH", False):
+            return runner.invoke(cli.app, ["booking", "bk_123", *args])
+
+    def test_completed_shows_pnr_and_captured_amount(self):
+        r = self._status({"state": "completed", "pnr": "ABC123", "charged_amount": 91.14, "currency": "EUR"})
+        self.assertEqual(r.exit_code, 0, r.output)
+        self.assertIn("ABC123", r.output)
+        self.assertIn("91.14 EUR", r.output)
+
+    def test_failed_says_the_hold_was_released(self):
+        r = self._status({"state": "failed", "failure_reason": "seller checkout dead", "decline_reason": ""})
+        self.assertIn("released", r.output)
+        self.assertIn("seller checkout dead", r.output)
+
+    def test_no_record_yet_is_not_an_error(self):
+        r = self._status({"state": "", "message": "No booking record yet for this ref."})
+        self.assertEqual(r.exit_code, 0, r.output)
+        self.assertIn("No booking record yet", r.output)
+
+    def test_status_posts_the_ref_with_the_bearer(self):
+        import asyncio
+        seen = {}
+
+        class _Resp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b'{"state":"booking_in_progress"}'
+
+        def fake_urlopen(req, timeout=30):
+            seen["url"] = req.full_url
+            seen["body"] = json.loads(req.data.decode())
+            seen["auth"] = req.get_header("Authorization")
+            return _Resp()
+
+        with patch.object(L, "ensure_bearer_token", lambda: "tok"), patch.object(L, "urlopen", fake_urlopen):
+            out = asyncio.run(L.booking_status("bk_9"))
+        self.assertEqual(out["state"], "booking_in_progress")
+        self.assertTrue(seen["url"].endswith("/api/agent-book/status"))
+        self.assertEqual(seen["body"], {"booking_ref": "bk_9"})
+        self.assertEqual(seen["auth"], "Bearer tok")
+
+
+class LocationsTest(unittest.TestCase):
+    def test_without_a_developer_key_it_says_so_instead_of_no_locations(self):
+        with patch.dict("os.environ", {"LETSFG_API_KEY": ""}), patch("letsfg.client._saved_api_key", lambda: None), \
+             patch.object(cli, "HAS_RICH", False):
+            r = runner.invoke(cli.app, ["locations", "London"])
+        self.assertEqual(r.exit_code, 1)
+        self.assertIn("API key", r.output)
+        self.assertNotIn("No locations found", r.output)
+
+
+class Utf8StreamsTest(unittest.TestCase):
+    def test_redirected_streams_are_switched_to_utf8(self):
+        class Pipe(io.TextIOWrapper):
+            pass
+        buf = io.BytesIO()
+        pipe = Pipe(buf, encoding="cp1252")
+        with patch.object(sys, "stdout", pipe), patch.object(sys, "stderr", pipe):
+            cli._utf8_streams()
+            print("WAW→BCN")
+        self.assertEqual(pipe.encoding, "utf-8")
+        pipe.flush()
+        self.assertIn("WAW→BCN".encode("utf-8"), buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #212, from driving the published CLI end to end (2026-09-11). Version 2026.5.100.

- **Table was all "-" except the price.** The renderer read a nested offer shape `/api/results` no longer returns. It now reads the flat offer (the offer is the outbound leg; the return is `inbound`), and shows every carrier of a multi-segment leg.
- **`--direct`, `--cabin`, `--sort` were ignored.** Sent as `max_stopovers`/`cabin_class`/`sort`; the route reads `max_stops`/`cabin`/`sort_by`. Verified live: a direct-only LON↔BCN round trip now returns only direct offers.
- **`letsfg book` hid the answer.** `missing_details` now lists the fields, `payment_method_required` shows the add-card link, `booking_ref` hands over the ref and the poll command. Verified live on a card-less account: both gates answered, nothing held.
- **New `letsfg booking <ref> [--wait]`** polls `/api/agent-book/status`.
- **Windows pipe crash.** Redirected stdout is cp1252 and died on `→`; redirected streams are UTF-8 and the table gets 160 columns instead of folding.
- **`letsfg locations` without a key** now says it needs a Developer API key instead of "No locations found for 'London'".

Also proven live with this build: the silent token refresh from 2026.5.99 (expired token → new access + rotated refresh token, command proceeds).

Tests: `tests/test_cli_offer_shape.py` (fixtures are trimmed real responses). 43 SDK auth/CLI tests pass locally. The required Python check is red on `main` with the same 17 pre-existing import errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUAYEJYyGDsASY2nxLWg7G
